### PR TITLE
Fix JSON-RPC parse error responses

### DIFF
--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -113,7 +113,9 @@ final class Server
         } catch (Throwable $e) {
             $this->container[ExceptionHandler::class]->report($e);
 
-            $this->respond(JsonRpcResponse::error(null, -32700, $e->getMessage()));
+            $this->respond(JsonRpcResponse::error(null, -32700, $e->getMessage(), [
+                'message' => $message,
+            ]));
 
             return;
         }

--- a/app/Lsp/Transport/JsonRpcResponse.php
+++ b/app/Lsp/Transport/JsonRpcResponse.php
@@ -59,7 +59,7 @@ class JsonRpcResponse
         }
 
         return new static([
-            ...$id === null ? [] : ['id' => $id],
+            'id'    => $id,
             'error' => $error,
         ]);
     }


### PR DESCRIPTION
## Summary

Fixes malformed JSON-RPC error responses emitted when the LSP server fails before it can decode a valid request.

Previously, parse/decode failures could produce an error object without an `id`, which VS Code rejects as neither a response nor a notification. Parse error responses now include `"id": null`, matching JSON-RPC expectations.

The response also includes the raw message body in `error.data.message` to make malformed inbound messages easier to debug.