### PR TITLE
Package LSP as a committed Composer binary

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -40,10 +40,6 @@ jobs:
           php-version: "8.2"
           extensions: bcmath,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,iconv,mbstring,openssl,pcntl,pdo_mysql,pdo_sqlite,pdo,phar,posix,readline,session,simplexml,sockets,sodium,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress --no-dev --quiet
-
       - name: Install SPC
         run: |
           curl -O -L "https://github.com/crazywhalecc/static-php-cli/releases/latest/download/spc-${{ matrix.spc_suffix }}"
@@ -51,11 +47,13 @@ jobs:
           chmod +x ./spc
           ./spc --version
 
-      - name: Build Binary
+      - name: Smoke Test Committed PHAR
         run: |
-          echo "" > .env
-          php server app:build --build-version=${{ github.ref_name }}
-          chmod +x ./builds/server && ./builds/server --version
+          chmod +x ./builds/laravel-lsp
+          VERSION=$(./builds/laravel-lsp --version)
+          echo "$VERSION"
+          [[ "$VERSION" == *"${{ github.ref_name }}"* ]]
+          ./builds/laravel-lsp list
 
       - name: Download PHP
         run: |
@@ -66,7 +64,7 @@ jobs:
 
       - name: SPC Combine
         run: |
-          ./spc micro:combine builds/server -O bin/server-${{ github.ref_name }}-${{ matrix.arch }}
+          ./spc micro:combine builds/laravel-lsp -O bin/server-${{ github.ref_name }}-${{ matrix.arch }}
 
       - name: Upload binary as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -91,18 +89,17 @@ jobs:
           php-version: "8.2"
           extensions: bcmath,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,iconv,mbstring,openssl,pcntl,pdo_mysql,pdo_sqlite,pdo,phar,posix,readline,session,simplexml,sockets,sodium,sqlite3,tokenizer,xml,xmlreader,xmlwriter,zip,zlib
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress --no-dev --quiet
-
       - name: Install SPC
         run: |
           curl -L -O https://github.com/crazywhalecc/static-php-cli/releases/latest/download/spc-windows-x64.exe
           .\spc-windows-x64.exe --version
 
-      - name: Build Binary
+      - name: Smoke Test Committed PHAR
         run: |
-          php server app:build --build-version=${{ github.ref_name }}
+          $version = php .\builds\laravel-lsp --version
+          $version
+          if (-not $version.Contains("${{ github.ref_name }}")) { exit 1 }
+          php .\builds\laravel-lsp list
 
       - name: Download PHP
         run: |
@@ -113,7 +110,7 @@ jobs:
 
       - name: SPC Combine
         run: |
-          .\spc-windows-x64.exe micro:combine builds/server -O bin/server-${{ github.ref_name }}-x64-win32
+          .\spc-windows-x64.exe micro:combine builds/laravel-lsp -O bin/server-${{ github.ref_name }}-x64-win32
 
       - name: Upload binary as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -127,6 +124,11 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Download all build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -135,6 +137,7 @@ jobs:
       - name: Flatten artifacts into release directory
         run: |
           mkdir -p release
+          cp builds/laravel-lsp release/laravel-lsp
           find dist -type f -name 'server-*' -exec cp {} release/ \;
 
       - name: Create release and upload binaries

--- a/box.json
+++ b/box.json
@@ -14,5 +14,6 @@
     "compactors": [
         "KevinGH\\Box\\Compactor\\Php",
         "KevinGH\\Box\\Compactor\\Json"
-    ]
+    ],
+    "exclude-dev-files": false
 }

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,16 @@
         }
     ],
     "require": {
-        "php": "^8.2.0",
-        "illuminate/log": "^11.5",
-        "laravel-zero/framework": "^11.0.0",
-        "microsoft/tolerant-php-parser": "^0.1.2",
-        "stillat/blade-parser": "^1.10"
+        "php": "^8.2.0"
     },
     "require-dev": {
+        "illuminate/log": "^11.5",
+        "laravel-zero/framework": "^11.0.0",
         "laravel/pint": "^1.15.2",
+        "microsoft/tolerant-php-parser": "^0.1.2",
         "mockery/mockery": "^1.6.11",
-        "pestphp/pest": "^2.34.7"
+        "pestphp/pest": "^2.34.7",
+        "stillat/blade-parser": "^1.10"
     },
     "autoload": {
         "psr-4": {
@@ -56,7 +56,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "bin": [
-        "server"
+        "builds/laravel-lsp"
     ],
     "scripts": {
         "pre-autoload-dump": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c495b79123811cb4cf98f615185475b7",
+    "content-hash": "96a54acba37f3210deacdb7bf3b148c9",
     "packages": [
         {
             "name": "brick/math",

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+abort() {
+    echo -e "${RED}Error: $1${RESET}" >&2
+    exit 1
+}
+
+info() {
+    echo -e "${CYAN}$1${RESET}"
+}
+
+success() {
+    echo -e "${GREEN}$1${RESET}"
+}
+
+# Check we're on main
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$BRANCH" != "main" ]; then
+    abort "You must be on the 'main' branch to release. Currently on: $BRANCH"
+fi
+
+# Fetch latest remote state
+info "Fetching latest remote state..."
+git fetch --tags origin
+
+# Check for dirty files
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    abort "You have uncommitted changes. Please commit or stash them before releasing."
+fi
+
+if [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    abort "You have untracked files. Please commit or remove them before releasing."
+fi
+
+# Check local is not ahead of remote
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main 2>/dev/null || echo "")
+
+if [ -z "$REMOTE" ]; then
+    abort "Could not find remote tracking branch 'origin/main'."
+fi
+
+AHEAD=$(git rev-list origin/main..HEAD --count)
+
+if [ "$AHEAD" -gt 0 ]; then
+    abort "Your branch is $AHEAD commit(s) ahead of origin/main. Push before releasing."
+fi
+
+# Check remote is not ahead of local
+BEHIND=$(git rev-list HEAD..origin/main --count)
+
+if [ "$BEHIND" -gt 0 ]; then
+    abort "Your branch is $BEHIND commit(s) behind origin/main. Pull before releasing."
+fi
+
+# Determine current latest tag
+CURRENT_TAG=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+if [ -z "$CURRENT_TAG" ]; then
+    CURRENT_TAG="v0.0.0"
+    info "No existing tags found. Starting from $CURRENT_TAG."
+else
+    info "Current latest tag: ${BOLD}$CURRENT_TAG${RESET}"
+fi
+
+# Parse version components
+VERSION="${CURRENT_TAG#v}"
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f2)
+PATCH=$(echo "$VERSION" | cut -d. -f3)
+
+NEXT_PATCH="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+NEXT_MINOR="v${MAJOR}.$((MINOR + 1)).0"
+NEXT_MAJOR="v$((MAJOR + 1)).0.0"
+
+echo ""
+echo -e "${BOLD}Select version bump type:${RESET}"
+echo -e "  1) patch  -> ${NEXT_PATCH}"
+echo -e "  2) minor  -> ${NEXT_MINOR}"
+echo -e "  3) major  -> ${NEXT_MAJOR}"
+echo ""
+
+while true; do
+    read -r -p "Choice [1/2/3]: " CHOICE
+
+    case "$CHOICE" in
+        1|patch)
+            NEW_TAG="$NEXT_PATCH"
+            break
+            ;;
+        2|minor)
+            NEW_TAG="$NEXT_MINOR"
+            break
+            ;;
+        3|major)
+            NEW_TAG="$NEXT_MAJOR"
+            break
+            ;;
+        *)
+            echo -e "${YELLOW}Please enter 1, 2, or 3.${RESET}"
+            ;;
+    esac
+done
+
+echo ""
+echo -e "New tag will be: ${BOLD}${GREEN}${NEW_TAG}${RESET}"
+echo ""
+
+read -r -p "Confirm and release $NEW_TAG? [y/N] " CONFIRM
+
+if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+if [ -f ".env" ]; then
+    mv .env .env.bak
+    info "Backed up .env to .env.bak"
+fi
+
+info "Building binary..."
+php server app:build laravel-lsp --build-version="$NEW_TAG"
+
+if [ -f ".env.bak" ]; then
+    mv .env.bak .env
+    info "Restored .env from .env.bak"
+fi
+
+info "Smoke testing binary..."
+
+if [ ! -f "builds/laravel-lsp" ]; then
+    abort "Build output builds/laravel-lsp not found."
+fi
+
+SMOKE_VERSION=$(./builds/laravel-lsp --version 2>&1) || abort "Binary failed to execute: $SMOKE_VERSION"
+
+if ! echo "$SMOKE_VERSION" | grep -qF "$NEW_TAG"; then
+    abort "Binary reported unexpected version. Expected '$NEW_TAG', got: $SMOKE_VERSION"
+fi
+
+./builds/laravel-lsp list >/dev/null 2>&1 || abort "Binary failed to list commands - bundled dependencies may be broken."
+
+success "Smoke test passed: $SMOKE_VERSION"
+
+info "Committing build..."
+git add builds/laravel-lsp
+git commit -m "Build $NEW_TAG"
+git tag "$NEW_TAG"
+git push origin main "$NEW_TAG"
+
+info "Pushed $NEW_TAG. GitHub Actions will create the release."
+
+REMOTE_URL=$(git remote get-url origin)
+REPO_PATH=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||;s|\.git$||')
+REPO_URL="https://github.com/${REPO_PATH}"
+
+echo ""
+success "Release $NEW_TAG started."
+echo ""
+echo -e "  Release:  ${CYAN}${REPO_URL}/releases/tag/${NEW_TAG}${RESET}"
+echo ""


### PR DESCRIPTION
- Move LSP runtime dependencies to `require-dev` and expose the committed `builds/laravel-lsp` PHAR through Composer’s `bin` config.
- Add a release helper that builds, smoke tests, commits, tags, and pushes the versioned LSP PHAR from a clean `main`.
- Update the release workflow to use the committed PHAR as the source for native release binaries instead of rebuilding it in CI.