### PR TITLE
Fix Blade and Livewire tag matching to detect multiple components per…

### DIFF
--- a/app/Lsp/Features/BladeComponents/BladeComponentDocumentMapper.php
+++ b/app/Lsp/Features/BladeComponents/BladeComponentDocumentMapper.php
@@ -136,17 +136,19 @@ class BladeComponentDocumentMapper
 
         foreach (explode("\n", $document->content) as $lineNumber => $line) {
             foreach ($patterns as $pattern) {
-                if (preg_match($pattern, $line, $match, PREG_OFFSET_CAPTURE) !== 1) {
+                if (preg_match_all($pattern, $line, $lineMatches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === false) {
                     continue;
                 }
 
-                $matches[] = [
-                    'name'  => $match[1][0],
-                    'range' => [
-                        'start' => ['line' => $lineNumber, 'character' => $match[0][1] + 1],
-                        'end'   => ['line' => $lineNumber, 'character' => $match[0][1] + strlen($match[0][0])],
-                    ],
-                ];
+                foreach ($lineMatches as $match) {
+                    $matches[] = [
+                        'name'  => $match[1][0],
+                        'range' => [
+                            'start' => ['line' => $lineNumber, 'character' => $match[0][1] + 1],
+                            'end'   => ['line' => $lineNumber, 'character' => $match[0][1] + strlen($match[0][0])],
+                        ],
+                    ];
+                }
             }
         }
 

--- a/app/Lsp/Features/LivewireComponents/LivewireComponentDocumentMapper.php
+++ b/app/Lsp/Features/LivewireComponents/LivewireComponentDocumentMapper.php
@@ -127,17 +127,19 @@ class LivewireComponentDocumentMapper
         $matches = [];
 
         foreach (explode("\n", $document->content) as $lineNumber => $line) {
-            if (preg_match('/<\/?livewire:([^\s>]+)/', $line, $match, PREG_OFFSET_CAPTURE) !== 1) {
+            if (preg_match_all('/<\/?livewire:([^\s>]+)/', $line, $lineMatches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER) === false) {
                 continue;
             }
 
-            $matches[] = [
-                'name'  => $match[1][0],
-                'range' => [
-                    'start' => ['line' => $lineNumber, 'character' => $match[0][1] + 1],
-                    'end'   => ['line' => $lineNumber, 'character' => $match[0][1] + strlen($match[0][0])],
-                ],
-            ];
+            foreach ($lineMatches as $match) {
+                $matches[] = [
+                    'name'  => $match[1][0],
+                    'range' => [
+                        'start' => ['line' => $lineNumber, 'character' => $match[0][1] + 1],
+                        'end'   => ['line' => $lineNumber, 'character' => $match[0][1] + strlen($match[0][0])],
+                    ],
+                ];
+            }
         }
 
         return $matches;


### PR DESCRIPTION
Blade and Livewire component tag matching used `preg_match` per line, so only the first tag on each line received a document link and hover. Switched to `preg_match_all` so every tag on a line is matched.

For example, previously only `<x-icon />` here would get a link/hover:

```blade
<x-icon /><x-badge />
```