### PR TITLE
Make DocumentMapper hover/diagnostics/completions conversions default…

### DIFF
--- a/app/Lsp/Features/Assets/AssetDocumentMapper.php
+++ b/app/Lsp/Features/Assets/AssetDocumentMapper.php
@@ -54,17 +54,6 @@ class AssetDocumentMapper extends DocumentMapper
     }
 
     /**
-     * Convert the given argument to hover.
-     *
-     * @param  array<string, mixed>  $position
-     * @return array<string, mixed>|null
-     */
-    protected function toHover(DetectedArgument $argument, array $position): ?array
-    {
-        return null;
-    }
-
-    /**
      * Convert the given argument to diagnostics.
      *
      * @return array<int, array<string, mixed>>

--- a/app/Lsp/Features/ControllerActions/ControllerActionDocumentMapper.php
+++ b/app/Lsp/Features/ControllerActions/ControllerActionDocumentMapper.php
@@ -59,17 +59,6 @@ class ControllerActionDocumentMapper extends DocumentMapper
     }
 
     /**
-     * Convert the given argument to hover.
-     *
-     * @param  array<string, mixed>  $position
-     * @return array<string, mixed>|null
-     */
-    protected function toHover(DetectedArgument $argument, array $position): ?array
-    {
-        return null;
-    }
-
-    /**
      * Convert the given argument to diagnostics.
      *
      * @return array<int, array<string, mixed>>

--- a/app/Lsp/Features/Paths/PathDocumentMapper.php
+++ b/app/Lsp/Features/Paths/PathDocumentMapper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Lsp\Features\Paths;
 
-use App\Lsp\Detection\AutocompleteArgument;
 use App\Lsp\Detection\DetectedArgument;
 use App\Lsp\Detection\Pattern;
 use App\Lsp\Features\Support\DocumentMapper;
@@ -58,37 +57,6 @@ class PathDocumentMapper extends DocumentMapper
                 'target' => (string) FileUri::fromPath($path),
             ]]
             : [];
-    }
-
-    /**
-     * Convert the given argument to hover.
-     *
-     * @param  array<string, mixed>  $position
-     * @return array<string, mixed>|null
-     */
-    protected function toHover(DetectedArgument $argument, array $position): ?array
-    {
-        return null;
-    }
-
-    /**
-     * Convert the given argument to diagnostics.
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    protected function toDiagnostics(DetectedArgument $argument): array
-    {
-        return [];
-    }
-
-    /**
-     * Convert the given argument to completion items.
-     *
-     * @return array<int, array<string, mixed>>
-     */
-    protected function toCompletions(AutocompleteArgument $argument): array
-    {
-        return [];
     }
 
     /**

--- a/app/Lsp/Features/Storage/StorageDocumentMapper.php
+++ b/app/Lsp/Features/Storage/StorageDocumentMapper.php
@@ -56,17 +56,6 @@ class StorageDocumentMapper extends DocumentMapper
     }
 
     /**
-     * Convert the given argument to hover.
-     *
-     * @param  array<string, mixed>  $position
-     * @return array<string, mixed>|null
-     */
-    protected function toHover(DetectedArgument $argument, array $position): ?array
-    {
-        return null;
-    }
-
-    /**
      * Convert the given argument to diagnostics.
      *
      * @return array<int, array<string, mixed>>

--- a/app/Lsp/Features/Support/DocumentMapper.php
+++ b/app/Lsp/Features/Support/DocumentMapper.php
@@ -34,21 +34,30 @@ abstract class DocumentMapper
      * @param  array<string, mixed>  $position
      * @return array<string, mixed>|null
      */
-    abstract protected function toHover(DetectedArgument $argument, array $position): ?array;
+    protected function toHover(DetectedArgument $argument, array $position): ?array
+    {
+        return null;
+    }
 
     /**
      * Convert the given argument to diagnostics.
      *
      * @return array<int, array<string, mixed>>
      */
-    abstract protected function toDiagnostics(DetectedArgument $argument): array;
+    protected function toDiagnostics(DetectedArgument $argument): array
+    {
+        return [];
+    }
 
     /**
      * Convert the given argument to completion items.
      *
      * @return array<int, array<string, mixed>>
      */
-    abstract protected function toCompletions(AutocompleteArgument $argument): array;
+    protected function toCompletions(AutocompleteArgument $argument): array
+    {
+        return [];
+    }
 
     /**
      * Get matched arguments from the document.


### PR DESCRIPTION
`toHover()`, `toDiagnostics()`, and `toCompletions()` on `DocumentMapper` are now opt-in with default-empty results instead of abstract. This removes the no-op stubs from the Assets, Storage, ControllerActions, and Paths mappers, so a feature without hover/diagnostics/completions simply omits the method.