### PR TITLE
Add AMPHP-backed request cancellation

### DIFF
--- a/app/Lsp/Exceptions/Handler.php
+++ b/app/Lsp/Exceptions/Handler.php
@@ -26,6 +26,10 @@ class Handler implements ExceptionHandler
      */
     public function report(Throwable $e): void
     {
+        if ($e instanceof RequestCancelledException) {
+            return;
+        }
+
         $this->logger->error($e->getMessage(), ['exception' => $e]);
     }
 

--- a/app/Lsp/Exceptions/RequestCancelledException.php
+++ b/app/Lsp/Exceptions/RequestCancelledException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Exceptions;
+
+use App\Lsp\Contracts\Responsable;
+use App\Lsp\Transport\JsonRpcRequest;
+use App\Lsp\Transport\JsonRpcResponse;
+use Exception;
+
+class RequestCancelledException extends Exception implements Responsable
+{
+    /**
+     * Instantiate a new class instance.
+     */
+    public function __construct()
+    {
+        parent::__construct('Request cancelled.');
+    }
+
+    /**
+     * Create a JSON-RPC response that represents the object.
+     */
+    public function toResponse(JsonRpcRequest $request): JsonRpcResponse
+    {
+        return JsonRpcResponse::error($request->id(), -32800, $this->getMessage());
+    }
+}

--- a/app/Lsp/Listeners/CancelRequest.php
+++ b/app/Lsp/Listeners/CancelRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Listeners;
+
+use App\Lsp\Contracts\Listener;
+use App\Lsp\Server;
+use App\Lsp\Transport\JsonRpcRequest;
+
+class CancelRequest implements Listener
+{
+    /**
+     * Instantiate a new class instance.
+     */
+    public function __construct(protected Server $server)
+    {
+        //
+    }
+
+    /**
+     * Handle the $/cancelRequest notification.
+     */
+    public function handle(JsonRpcRequest $request): void
+    {
+        $id = $request->get('id');
+
+        if (is_int($id) || is_string($id)) {
+            $this->server->cancel($id);
+        }
+    }
+}

--- a/app/Lsp/Methods/TextDocumentCodeAction.php
+++ b/app/Lsp/Methods/TextDocumentCodeAction.php
@@ -48,6 +48,8 @@ class TextDocumentCodeAction implements Method
 
         foreach ($this->features->codeActions() as $provider) {
             array_push($actions, ...$provider->get($document, $codeActionContext));
+
+            $request->cancelIfRequested();
         }
 
         return JsonRpcResponse::result($request->id(), $actions);

--- a/app/Lsp/Methods/TextDocumentCompletion.php
+++ b/app/Lsp/Methods/TextDocumentCompletion.php
@@ -51,6 +51,8 @@ class TextDocumentCompletion implements Method
             if ($items !== []) {
                 return JsonRpcResponse::result($request->id(), $items);
             }
+
+            $request->cancelIfRequested();
         }
 
         return JsonRpcResponse::result($request->id(), []);

--- a/app/Lsp/Methods/TextDocumentDefinition.php
+++ b/app/Lsp/Methods/TextDocumentDefinition.php
@@ -49,7 +49,7 @@ class TextDocumentDefinition implements Method
 
         $locationLinks = [];
 
-        foreach ($this->links($document) as $link) {
+        foreach ($this->links($request, $document) as $link) {
             $range = $link['range'] ?? null;
 
             if (!is_array($range) || !Position::inRange($range, $position)) {
@@ -67,12 +67,14 @@ class TextDocumentDefinition implements Method
      *
      * @return array<int, array<string, mixed>>
      */
-    protected function links(Document $document): array
+    protected function links(JsonRpcRequest $request, Document $document): array
     {
         $links = [];
 
         foreach ($this->features->links() as $provider) {
             array_push($links, ...$provider->get($document));
+
+            $request->cancelIfRequested();
         }
 
         return $links;

--- a/app/Lsp/Methods/TextDocumentDocumentLink.php
+++ b/app/Lsp/Methods/TextDocumentDocumentLink.php
@@ -39,6 +39,8 @@ class TextDocumentDocumentLink implements Method
 
         foreach ($this->features->links() as $provider) {
             array_push($links, ...$provider->get($document));
+
+            $request->cancelIfRequested();
         }
 
         return JsonRpcResponse::result($request->id(), $links);

--- a/app/Lsp/Methods/TextDocumentHover.php
+++ b/app/Lsp/Methods/TextDocumentHover.php
@@ -47,6 +47,8 @@ class TextDocumentHover implements Method
             if ($hover !== null) {
                 return JsonRpcResponse::result($request->id(), $hover);
             }
+
+            $request->cancelIfRequested();
         }
 
         return JsonRpcResponse::result($request->id(), null);

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Lsp;
 
+use Amp\DeferredCancellation;
 use App\Lsp\Contracts\ExceptionHandler;
 use App\Lsp\Contracts\Listener;
 use App\Lsp\Contracts\Method;
@@ -12,6 +13,7 @@ use App\Lsp\Exceptions\Handler;
 use App\Lsp\Exceptions\MethodNotFoundException;
 use App\Lsp\Exceptions\ParseException;
 use App\Lsp\Exceptions\ServerNotInitializedException;
+use App\Lsp\Listeners\CancelRequest;
 use App\Lsp\Listeners\ClearDocumentDiagnostics;
 use App\Lsp\Listeners\CloseDocument;
 use App\Lsp\Listeners\NotifyFileWatchers;
@@ -27,15 +29,17 @@ use App\Lsp\Methods\TextDocumentCompletion;
 use App\Lsp\Methods\TextDocumentDefinition;
 use App\Lsp\Methods\TextDocumentDocumentLink;
 use App\Lsp\Methods\TextDocumentHover;
+use App\Lsp\Transport\AmpStdioTransport;
 use App\Lsp\Transport\JsonRpcRequest;
 use App\Lsp\Transport\JsonRpcResponse;
-use App\Lsp\Transport\StdioTransport;
 use Illuminate\Container\Container;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
+
+use function Amp\async;
 
 final class Server
 {
@@ -45,13 +49,13 @@ final class Server
      * @var array<string, class-string<Method>>
      */
     protected array $handlers = [
-        'initialize' => Initialize::class,
-        'laravel/data' => LaravelData::class,
-        'textDocument/codeAction' => TextDocumentCodeAction::class,
-        'textDocument/completion' => TextDocumentCompletion::class,
-        'textDocument/definition' => TextDocumentDefinition::class,
+        'initialize'                => Initialize::class,
+        'laravel/data'              => LaravelData::class,
+        'textDocument/codeAction'   => TextDocumentCodeAction::class,
+        'textDocument/completion'   => TextDocumentCompletion::class,
+        'textDocument/definition'   => TextDocumentDefinition::class,
         'textDocument/documentLink' => TextDocumentDocumentLink::class,
-        'textDocument/hover' => TextDocumentHover::class,
+        'textDocument/hover'        => TextDocumentHover::class,
     ];
 
     /**
@@ -60,10 +64,11 @@ final class Server
      * @var array<string, array<int, class-string<Listener>>>
      */
     protected array $listeners = [
-        'initialized' => [RegisterFileWatchers::class],
-        'textDocument/didOpen' => [OpenDocument::class, PublishDiagnostics::class],
-        'textDocument/didChange' => [UpdateDocument::class, PublishDiagnostics::class],
-        'textDocument/didClose' => [CloseDocument::class, ClearDocumentDiagnostics::class],
+        '$/cancelRequest'                 => [CancelRequest::class],
+        'initialized'                     => [RegisterFileWatchers::class],
+        'textDocument/didOpen'            => [OpenDocument::class, PublishDiagnostics::class],
+        'textDocument/didChange'          => [UpdateDocument::class, PublishDiagnostics::class],
+        'textDocument/didClose'           => [CloseDocument::class, ClearDocumentDiagnostics::class],
         'workspace/didChangeWatchedFiles' => [NotifyFileWatchers::class, PublishOpenDocumentDiagnostics::class],
     ];
 
@@ -71,6 +76,13 @@ final class Server
      * Store the last sent request id.
      */
     protected int $lastRequestId = 0;
+
+    /**
+     * The cancellation sources of in-flight asynchronous requests.
+     *
+     * @var array<int|string, DeferredCancellation>
+     */
+    protected array $cancellations = [];
 
     /**
      * Instantiate a new class instance.
@@ -88,8 +100,8 @@ final class Server
      */
     public static function stdio(): static
     {
-        return new static(
-            new StdioTransport,
+        return new self(
+            new AmpStdioTransport,
             new Logger('Laravel LSP', [new StreamHandler('php://stderr')]),
         );
     }
@@ -124,11 +136,7 @@ final class Server
             return;
         }
 
-        $response = $this->dispatch($request);
-
-        if (! is_null($response)) {
-            $this->respond($response);
-        }
+        $this->dispatch($request);
     }
 
     /**
@@ -146,11 +154,11 @@ final class Server
     {
         $data = [
             'jsonrpc' => '2.0',
-            'id' => $this->lastRequestId++,
-            'method' => $method,
+            'id'      => $this->lastRequestId++,
+            'method'  => $method,
         ];
 
-        if (! is_null($params)) {
+        if (!is_null($params)) {
             $data['params'] = $params;
         }
 
@@ -164,10 +172,10 @@ final class Server
     {
         $data = [
             'jsonrpc' => '2.0',
-            'method' => $method,
+            'method'  => $method,
         ];
 
-        if (! is_null($params)) {
+        if (!is_null($params)) {
             $data['params'] = $params;
         }
 
@@ -199,7 +207,7 @@ final class Server
      */
     protected function isResponse(array $payload): bool
     {
-        return ! isset($payload['method'])
+        return !isset($payload['method'])
             && array_key_exists('id', $payload)
             && (array_key_exists('result', $payload) || array_key_exists('error', $payload));
     }
@@ -207,42 +215,65 @@ final class Server
     /**
      * Dispatch the request.
      */
-    public function dispatch(JsonRpcRequest $request): ?JsonRpcResponse
+    public function dispatch(JsonRpcRequest $request): void
     {
         if ($request->isNotification()) {
             $this->dispatchNotification($request);
 
-            return null;
+            return;
         }
 
-        return $this->dispatchRequest($request);
+        $this->dispatchRequest($request);
     }
 
     /**
-     * Handle the notification.
+     * Handle the notification asynchronously.
      */
     public function dispatchNotification(JsonRpcRequest $request): void
     {
-        foreach ($this->listeners($request->method()) as $listener) {
-            try {
-                $listener->handle($request);
-            } catch (Throwable $e) {
-                $this->container[ExceptionHandler::class]->report($e);
+        async(function () use ($request): void {
+            foreach ($this->listeners($request->method()) as $listener) {
+                try {
+                    $listener->handle($request);
+                } catch (Throwable $e) {
+                    $this->container[ExceptionHandler::class]->report($e);
+                }
             }
-        }
+        });
     }
 
     /**
-     * Handle request.
+     * Handle the request asynchronously, responding from its own fiber.
      */
-    public function dispatchRequest(JsonRpcRequest $request): JsonRpcResponse
+    public function dispatchRequest(JsonRpcRequest $request): void
     {
-        try {
-            return $this->handler($request->method())->handle($request);
-        } catch (Throwable $e) {
-            $this->container[ExceptionHandler::class]->report($e);
+        $deferred = new DeferredCancellation;
 
-            return $this->container[ExceptionHandler::class]->render($request, $e);
+        $this->cancellations[$request->id()] = $deferred;
+        $request->setCancellation($deferred->getCancellation());
+
+        async(function () use ($request): void {
+            try {
+                $response = $this->handler($request->method())->handle($request);
+            } catch (Throwable $e) {
+                $this->container[ExceptionHandler::class]->report($e);
+
+                $response = $this->container[ExceptionHandler::class]->render($request, $e);
+            } finally {
+                unset($this->cancellations[$request->id()]);
+            }
+
+            $this->respond($response);
+        });
+    }
+
+    /**
+     * Cancel the in-flight request with the given id.
+     */
+    public function cancel(int|string $id): void
+    {
+        if (isset($this->cancellations[$id])) {
+            $this->cancellations[$id]->cancel();
         }
     }
 

--- a/app/Lsp/Transport/AmpStdioTransport.php
+++ b/app/Lsp/Transport/AmpStdioTransport.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Transport;
+
+use Amp\ByteStream\ReadableResourceStream;
+use Amp\ByteStream\WritableResourceStream;
+use App\Lsp\Contracts\Transport;
+use Closure;
+
+class AmpStdioTransport implements Transport
+{
+    /**
+     * The message handler callback.
+     *
+     * @var (Closure(string): void)|null
+     */
+    protected ?Closure $handler = null;
+
+    /**
+     * The non-blocking STDIN stream.
+     */
+    protected ReadableResourceStream $stdin;
+
+    /**
+     * The non-blocking STDOUT stream.
+     */
+    protected WritableResourceStream $stdout;
+
+    /**
+     * The buffer of incoming bytes pending frame extraction.
+     */
+    protected string $buffer = '';
+
+    /**
+     * Instantiate a new class instance.
+     */
+    public function __construct()
+    {
+        $this->stdin = new ReadableResourceStream(STDIN);
+        $this->stdout = new WritableResourceStream(STDOUT);
+    }
+
+    /**
+     * Register a handler for incoming messages.
+     */
+    public function onReceive(Closure $handler): void
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * Send a message to the client with LSP Content-Length framing.
+     */
+    public function send(string $message): void
+    {
+        $length = strlen($message);
+
+        $this->stdout->write("Content-Length: {$length}\r\n\r\n{$message}");
+    }
+
+    /**
+     * Start the main event loop, reading from STDIN.
+     */
+    public function run(): void
+    {
+        while (($chunk = $this->stdin->read()) !== null) {
+            $this->buffer .= $chunk;
+
+            while (($message = $this->extractMessage()) !== null) {
+                if (is_callable($this->handler)) {
+                    ($this->handler)($message);
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract the next complete Content-Length framed message from the buffer.
+     */
+    protected function extractMessage(): ?string
+    {
+        $separator = strpos($this->buffer, "\r\n\r\n");
+
+        if ($separator === false) {
+            return null;
+        }
+
+        $length = $this->parseContentLength(substr($this->buffer, 0, $separator));
+
+        if ($length === null) {
+            $this->buffer = substr($this->buffer, $separator + 4);
+
+            return $this->extractMessage();
+        }
+
+        $offset = $separator + 4;
+
+        if (strlen($this->buffer) < $offset + $length) {
+            return null;
+        }
+
+        $body = substr($this->buffer, $offset, $length);
+
+        $this->buffer = substr($this->buffer, $offset + $length);
+
+        return $body;
+    }
+
+    /**
+     * Extract the Content-Length value from the raw headers.
+     */
+    protected function parseContentLength(string $headers): ?int
+    {
+        if (preg_match('/Content-Length:\s*(\d+)/i', $headers, $matches)) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/app/Lsp/Transport/JsonRpcRequest.php
+++ b/app/Lsp/Transport/JsonRpcRequest.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace App\Lsp\Transport;
 
+use Amp\Cancellation;
+use App\Lsp\Exceptions\RequestCancelledException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\InteractsWithData;
+
+use function Amp\delay;
 
 class JsonRpcRequest
 {
     use InteractsWithData;
+
+    /**
+     * The cancellation source for the request.
+     */
+    protected ?Cancellation $cancellation = null;
 
     /**
      * Create a new JSON-RPC request instance.
@@ -74,6 +83,33 @@ class JsonRpcRequest
     public function isNotification(): bool
     {
         return $this->notification;
+    }
+
+    /**
+     * Set the cancellation source for the request.
+     */
+    public function setCancellation(Cancellation $cancellation): void
+    {
+        $this->cancellation = $cancellation;
+    }
+
+    /**
+     * Throw if the request has been cancelled.
+     *
+     * @throws RequestCancelledException
+     */
+    public function cancelIfRequested(): void
+    {
+        if ($this->cancellation === null) {
+            return;
+        }
+
+        // Yield to the event loop so a pending $/cancelRequest can be read.
+        delay(0);
+
+        if ($this->cancellation->isRequested()) {
+            throw new RequestCancelledException;
+        }
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,8 @@
         "php": "^8.2.0"
     },
     "require-dev": {
+        "amphp/amp": "^3.0",
+        "amphp/byte-stream": "^2.1",
         "laravel-zero/framework": "^12.0",
         "laravel/pint": "^1.15.2",
         "microsoft/tolerant-php-parser": "^0.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,436 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bdb0f775b119ce15d7db7e29c987f84",
+    "content-hash": "f098d316a9d1ca6a1397d8f3037a89df",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-27T21:42:00+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "https://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-16T17:10:27+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "a044733e080940d1483f56caff0c412ad6982776"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/a044733e080940d1483f56caff0c412ad6982776",
+                "reference": "a044733e080940d1483f56caff0c412ad6982776",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-06T05:37:57+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
+        },
         {
             "name": "brianium/paratest",
             "version": "v7.20.0",
@@ -231,28 +658,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -290,7 +718,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -300,13 +728,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -3840,16 +4264,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.7.2",
+            "version": "v4.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "40b88b62ef8a7c6fcae5fc28f1fa747f601c131b"
+                "reference": "87882a8561bf3ddf230b9a6b764f367f687d5b2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/40b88b62ef8a7c6fcae5fc28f1fa747f601c131b",
-                "reference": "40b88b62ef8a7c6fcae5fc28f1fa747f601c131b",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/87882a8561bf3ddf230b9a6b764f367f687d5b2f",
+                "reference": "87882a8561bf3ddf230b9a6b764f367f687d5b2f",
                 "shasum": ""
             },
             "require": {
@@ -3862,12 +4286,12 @@
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.28",
+                "phpunit/phpunit": "^12.5.29",
                 "symfony/process": "^7.4.13|^8.1.0"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.28",
+                "phpunit/phpunit": ">12.5.29",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
@@ -3943,7 +4367,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.7.2"
+                "source": "https://github.com/pestphp/pest/tree/v4.7.3"
             },
             "funding": [
                 {
@@ -3955,7 +4379,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-01T06:08:59+00:00"
+            "time": "2026-06-12T05:57:27+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -4992,16 +5416,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.28",
+            "version": "12.5.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4"
+                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5895d05f5bf421ed230fbd76e1277e4b8955def4",
-                "reference": "5895d05f5bf421ed230fbd76e1277e4b8955def4",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9aa66a47db3ea70f1a468e66dd969f67e594945a",
+                "reference": "9aa66a47db3ea70f1a468e66dd969f67e594945a",
                 "shasum": ""
             },
             "require": {
@@ -5015,7 +5439,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-code-coverage": "^12.5.7",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
@@ -5025,7 +5449,7 @@
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.1.2",
                 "sebastian/exporter": "^7.0.3",
-                "sebastian/global-state": "^8.0.2",
+                "sebastian/global-state": "^8.0.3",
                 "sebastian/object-enumerator": "^7.0.0",
                 "sebastian/recursion-context": "^7.0.1",
                 "sebastian/type": "^6.0.4",
@@ -5070,7 +5494,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.28"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.29"
             },
             "funding": [
                 {
@@ -5078,7 +5502,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-05-27T14:01:10+00:00"
+            "time": "2026-06-04T06:14:42+00:00"
         },
         {
             "name": "psr/clock",
@@ -5689,6 +6113,78 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
+            },
+            "time": "2026-05-16T17:55:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
This introduces AMPHP-based async dispatching in the LSP server.

Besides improving request handling performance, the main benefit is that pending requests can now be cancelled when the client sends `$/cancelRequest`, avoiding unnecessary work for stale LSP requests.