### PR TITLE
Move async request dispatch into transports

### DIFF
--- a/app/Lsp/Contracts/Transport.php
+++ b/app/Lsp/Contracts/Transport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Lsp\Contracts;
 
+use App\Lsp\Transport\JsonRpcRequest;
 use Closure;
 
 interface Transport
@@ -14,6 +15,18 @@ interface Transport
      * @param  (Closure(string): void)  $handler
      */
     public function onReceive(Closure $handler): void;
+
+    /**
+     * Dispatch an incoming JSON-RPC request.
+     *
+     * @param  (Closure(JsonRpcRequest): void)  $dispatch
+     */
+    public function dispatch(JsonRpcRequest $request, Closure $dispatch): void;
+
+    /**
+     * Cancel the in-flight request with the given id.
+     */
+    public function cancel(int|string $id): void;
 
     /**
      * Start listening for incoming messages.

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Lsp;
 
-use Amp\DeferredCancellation;
 use App\Lsp\Contracts\ExceptionHandler;
 use App\Lsp\Contracts\Listener;
 use App\Lsp\Contracts\Method;
@@ -39,8 +38,6 @@ use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
-
-use function Amp\async;
 
 final class Server
 {
@@ -79,20 +76,12 @@ final class Server
     protected int $lastRequestId = 0;
 
     /**
-     * The cancellation sources of in-flight asynchronous requests.
-     *
-     * @var array<int|string, DeferredCancellation>
-     */
-    protected array $cancellations = [];
-
-    /**
      * Instantiate a new class instance.
      */
     public function __construct(
         protected Transport $transport,
         protected LoggerInterface $logger = new NullLogger,
         protected Container $container = new Container,
-        protected bool $async = true,
     ) {
         $this->registerBaseBindings();
     }
@@ -105,7 +94,6 @@ final class Server
         return new self(
             new StdioTransport,
             new Logger('Laravel LSP', [new StreamHandler('php://stderr')]),
-            async: false,
         );
     }
 
@@ -117,7 +105,6 @@ final class Server
         return new self(
             new AmpStdioTransport,
             new Logger('Laravel LSP', [new StreamHandler('php://stderr')]),
-            async: true,
         );
     }
 
@@ -151,7 +138,7 @@ final class Server
             return;
         }
 
-        $this->dispatch($request);
+        $this->transport->dispatch($request, $this->dispatch(...));
     }
 
     /**
@@ -242,46 +229,19 @@ final class Server
     }
 
     /**
-     * Handle the notification asynchronously.
+     * Dispatch the notification.
      */
     public function dispatchNotification(JsonRpcRequest $request): void
     {
-        if (!$this->async) {
-            $this->handleNotification($request);
-
-            return;
-        }
-
-        async(function () use ($request): void {
-            $this->handleNotification($request);
-        });
+        $this->handleNotification($request);
     }
 
     /**
-     * Handle the request asynchronously, responding from its own fiber.
+     * Dispatch the request.
      */
     public function dispatchRequest(JsonRpcRequest $request): void
     {
-        if (!$this->async) {
-            $this->respond($this->handleRequest($request));
-
-            return;
-        }
-
-        $deferred = new DeferredCancellation;
-
-        $this->cancellations[$request->id()] = $deferred;
-        $request->setCancellation($deferred->getCancellation());
-
-        async(function () use ($request): void {
-            try {
-                $response = $this->handleRequest($request);
-            } finally {
-                unset($this->cancellations[$request->id()]);
-            }
-
-            $this->respond($response);
-        });
+        $this->respond($this->handleRequest($request));
     }
 
     /**
@@ -317,9 +277,7 @@ final class Server
      */
     public function cancel(int|string $id): void
     {
-        if (isset($this->cancellations[$id])) {
-            $this->cancellations[$id]->cancel();
-        }
+        $this->transport->cancel($id);
     }
 
     /**

--- a/app/Lsp/Transport/AmpStdioTransport.php
+++ b/app/Lsp/Transport/AmpStdioTransport.php
@@ -6,8 +6,11 @@ namespace App\Lsp\Transport;
 
 use Amp\ByteStream\ReadableResourceStream;
 use Amp\ByteStream\WritableResourceStream;
+use Amp\DeferredCancellation;
 use App\Lsp\Contracts\Transport;
 use Closure;
+
+use function Amp\async;
 
 class AmpStdioTransport implements Transport
 {
@@ -34,6 +37,13 @@ class AmpStdioTransport implements Transport
     protected string $buffer = '';
 
     /**
+     * The cancellation sources of in-flight asynchronous requests.
+     *
+     * @var array<int|string, DeferredCancellation>
+     */
+    protected array $cancellations = [];
+
+    /**
      * Instantiate a new class instance.
      */
     public function __construct()
@@ -48,6 +58,43 @@ class AmpStdioTransport implements Transport
     public function onReceive(Closure $handler): void
     {
         $this->handler = $handler;
+    }
+
+    /**
+     * Dispatch an incoming JSON-RPC request.
+     *
+     * @param  (Closure(JsonRpcRequest): void)  $dispatch
+     */
+    public function dispatch(JsonRpcRequest $request, Closure $dispatch): void
+    {
+        if ($request->isNotification()) {
+            async(fn () => $dispatch($request));
+
+            return;
+        }
+
+        $deferred = new DeferredCancellation;
+
+        $this->cancellations[$request->id()] = $deferred;
+        $request->setCancellation($deferred->getCancellation());
+
+        async(function () use ($request, $dispatch): void {
+            try {
+                $dispatch($request);
+            } finally {
+                unset($this->cancellations[$request->id()]);
+            }
+        });
+    }
+
+    /**
+     * Cancel the in-flight request with the given id.
+     */
+    public function cancel(int|string $id): void
+    {
+        if (isset($this->cancellations[$id])) {
+            $this->cancellations[$id]->cancel();
+        }
     }
 
     /**

--- a/app/Lsp/Transport/StdioTransport.php
+++ b/app/Lsp/Transport/StdioTransport.php
@@ -25,6 +25,24 @@ class StdioTransport implements Transport
     }
 
     /**
+     * Dispatch an incoming JSON-RPC request.
+     *
+     * @param  (Closure(JsonRpcRequest): void)  $dispatch
+     */
+    public function dispatch(JsonRpcRequest $request, Closure $dispatch): void
+    {
+        $dispatch($request);
+    }
+
+    /**
+     * Cancel the in-flight request with the given id.
+     */
+    public function cancel(int|string $id): void
+    {
+        //
+    }
+
+    /**
      * Send a message to the client with LSP Content-Length framing.
      */
     public function send(string $message): void


### PR DESCRIPTION
Refactors LSP dispatching so Server delegates decoded JSON-RPC requests to the active transport. `AmpStdioTransport` now owns async execution and cancellation tracking, while `StdioTransport` dispatches synchronously with cancellation as a no-op. This keeps server logic focused on request routing, response handling, and LSP behavior.