### PR TITLE
Avoid translation diagnostics for sentence literals

### DIFF
--- a/app/Lsp/Features/Translations/TranslationDocumentMapper.php
+++ b/app/Lsp/Features/Translations/TranslationDocumentMapper.php
@@ -93,7 +93,7 @@ class TranslationDocumentMapper extends DocumentMapper
     {
         $value = $argument->stringValue();
 
-        if ($value === null || is_array($this->find($value))) {
+        if ($value === null || !$this->isLikelyKeyLiteral($value) || is_array($this->find($value))) {
             return [];
         }
 
@@ -104,6 +104,17 @@ class TranslationDocumentMapper extends DocumentMapper
             'code'     => 'translation',
             'message'  => "Translation [{$value}] not found.",
         ]];
+    }
+
+    /**
+     * Determine if the given translation literal looks like a key.
+     */
+    protected function isLikelyKeyLiteral(string $value): bool
+    {
+        return preg_match(
+            '/^(?:[A-Za-z0-9_\\-\\/]+::)?[A-Za-z0-9_\\-\\/]+(?:\\.[A-Za-z0-9_\\-\\/]+)+$/',
+            $value,
+        ) === 1;
     }
 
     /**


### PR DESCRIPTION
Adds a key-shape check before reporting missing translation diagnostics, so sentence-style literals like `trans('Hello, how are you?')` are not flagged as missing translations.

The regular expression treats a string as a likely translation key when it has key-safe characters, contains a dot between non-empty segments, and optionally starts with a namespace like `vendor::`. Missing-key diagnostics still apply to literals such as `auth.failed`, `messages.title`, and `vendor::file.key`.

Fixes: https://github.com/laravel/lsp/issues/35