### PR TITLE
Fix config completions after typing a dot

### DIFF
--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -73,7 +73,7 @@ final class Initialize implements Method
                     'resolveProvider' => false,
                 ],
                 'completionProvider' => [
-                    'triggerCharacters' => ['"', "'", '|', 'x', '-', ':', '@'],
+                    'triggerCharacters' => ['"', "'", '.', '|', 'x', '-', ':', '@'],
                 ],
                 'codeActionProvider' => [
                     'codeActionKinds' => ['quickfix'],

--- a/app/Parser/Walker.php
+++ b/app/Parser/Walker.php
@@ -41,7 +41,7 @@ class Walker
         }
 
         foreach ($this->sourceFile->getDescendantNodesAndTokens() as $child) {
-            if ($child instanceof SkippedToken && $child->getText($this->sourceFile->getFullText()) === "'") {
+            if ($child instanceof SkippedToken && str_starts_with($child->getText($this->sourceFile->getFullText()), "'")) {
                 return true;
             }
         }


### PR DESCRIPTION
- Advertise `.` as an LSP completion trigger character.
- Recognize incomplete single-quoted arguments that already contain text.
- Preserve config completions when typing dotted keys such as `config('app..`

Previously, completions were initially provided after the opening quote and filtered locally by the editor. Typing a dot required a new completion request, but the server neither advertised `.` as a trigger nor recognized the resulting `'app.` token as an incomplete string.