### PR TITLE
Filter completions using the full replacement text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-The Laravel language server provides framework-aware editor features for Laravel applications. It runs over stdio using the Language Server Protocol and powers completions, hovers, diagnostics, document links, definitions, and quick fixes for Laravel and Blade code.
+The Laravel language server provides framework-aware editor features for Laravel applications. It powers code completions, hover information, diagnostics, document links, go-to definition, and quick fixes for Laravel and Blade code.
 
 ## Installation
 

--- a/app/Lsp/Methods/TextDocumentCompletion.php
+++ b/app/Lsp/Methods/TextDocumentCompletion.php
@@ -8,6 +8,7 @@ use App\Lsp\Contracts\Method;
 use App\Lsp\DocumentManager;
 use App\Lsp\FeatureRegistry;
 use App\Lsp\Project;
+use App\Lsp\Support\CompletionItems;
 use App\Lsp\Transport\JsonRpcRequest;
 use App\Lsp\Transport\JsonRpcResponse;
 
@@ -49,7 +50,10 @@ class TextDocumentCompletion implements Method
             $items = $provider->get($document, $position);
 
             if ($items !== []) {
-                return JsonRpcResponse::result($request->id(), $items);
+                return JsonRpcResponse::result(
+                    $request->id(),
+                    CompletionItems::matching($document, $items),
+                );
             }
 
             $request->cancelIfRequested();

--- a/app/Lsp/Support/CompletionItems.php
+++ b/app/Lsp/Support/CompletionItems.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Support;
+
+use App\Lsp\Document;
+
+class CompletionItems
+{
+    /**
+     * Filter completion items using the complete text in their replacement ranges.
+     *
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<int, array<string, mixed>>
+     */
+    public static function matching(Document $document, array $items): array
+    {
+        return collect($items)
+            ->filter(fn (array $item): bool => self::matches($document, $item))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Determine if the completion item matches the text it will replace.
+     *
+     * @param  array<string, mixed>  $item
+     */
+    protected static function matches(Document $document, array $item): bool
+    {
+        $textEdit = $item['textEdit'] ?? null;
+
+        if (!is_array($textEdit)) {
+            return true;
+        }
+
+        $range = $textEdit['range'] ?? null;
+
+        if (!is_array($range)) {
+            return true;
+        }
+
+        $prefix = $document->textInRange($range);
+
+        if ($prefix === '') {
+            return true;
+        }
+
+        $filterText = $item['filterText'] ?? $item['label'] ?? null;
+
+        return !is_string($filterText)
+            || strncasecmp($filterText, $prefix, strlen($prefix)) === 0;
+    }
+}


### PR DESCRIPTION
Fix autocomplete suggestions for dotted values across all completion providers.

For example, typing config('app.time will now only suggest options beginning with app.time, instead of unrelated options containing time.