### PR TITLE
[Fix] Check for logging dir writabilty

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,9 +36,24 @@ class AppServiceProvider extends ServiceProvider
         }
 
         File::ensureDirectoryExists(
-            $dir = dirname(Phar::running(false)) . '/logs'
+            $dir = $this->getCompiledLoggingDirectory()
         );
 
         return $dir . '/lsp.log';
+    }
+
+    /**
+     * Get the logging directory when running as a compiled binary.
+     */
+    protected function getCompiledLoggingDirectory(): string
+    {
+        $dir = dirname(Phar::running(false)) . '/logs';
+        $dirIsWritable = is_dir($dir) ? is_writable($dir) : is_writable(dirname($dir));
+
+        if ($dirIsWritable) {
+            return $dir;
+        }
+
+        return sys_get_temp_dir() . '/laravel-lsp/logs';
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -31,29 +31,24 @@ class AppServiceProvider extends ServiceProvider
      */
     protected function getLoggingPath(): string
     {
-        if (!Phar::running()) {
-            return storage_path('logs/lsp.log');
+        $dir = Phar::running()
+            ? dirname(Phar::running(false)) . '/logs'
+            : storage_path('logs');
+
+        if (!$this->isWritableLoggingDirectory($dir)) {
+            $dir = sys_get_temp_dir() . '/laravel-lsp/logs';
         }
 
-        File::ensureDirectoryExists(
-            $dir = $this->getCompiledLoggingDirectory()
-        );
+        File::ensureDirectoryExists($dir);
 
         return $dir . '/lsp.log';
     }
 
     /**
-     * Get the logging directory when running as a compiled binary.
+     * Determine if logs can be written to the given directory.
      */
-    protected function getCompiledLoggingDirectory(): string
+    protected function isWritableLoggingDirectory(string $dir): bool
     {
-        $dir = dirname(Phar::running(false)) . '/logs';
-        $dirIsWritable = is_dir($dir) ? is_writable($dir) : is_writable(dirname($dir));
-
-        if ($dirIsWritable) {
-            return $dir;
-        }
-
-        return sys_get_temp_dir() . '/laravel-lsp/logs';
+        return is_dir($dir) ? is_writable($dir) : is_writable(dirname($dir));
     }
 }


### PR DESCRIPTION
This came about after watching Taylor's talk at Laracon today. As a fellow neovimer, I couldn't be more stoked for this LSP. Awesome work!

## Problem

When running as a compiled binary, the server eagerly creates a `logs/` directory next to the binary during boot (`AppServiceProvider::boot()` -> `File::ensureDirectoryExists()`). If the binary is installed in a read-only location, the `mkdir()` warning is promoted to an `ErrorException` and the server crashes before serving a single request:

```
production.ERROR: mkdir(): Permission denied {"exception":"[object] (ErrorException ...
```

It doesn't look like the compiled binary ships a `.env`, so the default log channel is `stderr`, meaning the boot crash happens on behalf of a log file that is typically never written.

For most Laravelians installing via `composer global require`, this never surfaces since Composer's bin directory is writable, but it breaks any read-only install location. In my case, that's the Nix store (immutable by design). The same applies to system package installs. My current workaround in my [dotfiles](https://github.com/JoeyMckenzie/dotfiles/blob/ca4147b5514104c06432a60263de2fe64b357c24/nix-darwin/home/neovim/_pkgs/laravel-lsp.nix#L58) is to copy the binary into a writable per-user cache directory at launch, purely so the adjacent `logs/` directory can be created. 

It's a bit hacky, and it would be nice if the LSP could have a) configurable storage path for logs, or b) create one if it's not in a writable location on disk.

## Solution

Opting for solution b) in this case. 

Check whether the binary-adjacent `logs/` directory is (or can be made) writable, and fall back to `sys_get_temp_dir() . '/laravel-lsp/logs'` when it isn't. Writable installs keep exactly the behavior they have today. Verified with a locally built binary (`app:build`) run from a `chmod 555` directory:

- **Before:** crashes at boot with the `mkdir` error above
- **After:** boots cleanly, responds to `initialize`, logs land in the temp fallback
- **Writable directory:** unchanged, `logs/` is still created next to the binary

The big benefit here is that with these changes, I could submit the LSP to [nixpkgs](https://github.com/nixos/nixpkgs) and make it easy for folks to bring the LSP into their nix-managed setups. More than happy to upstream that!


Generated by a human 👴🏻