### PR TITLE
Parse PHP expressions in component parameters

### DIFF
--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -12,6 +12,9 @@ use Microsoft\PhpParser\PositionUtilities;
 use Microsoft\PhpParser\Range;
 use Stillat\BladeParser\Document\Document;
 use Stillat\BladeParser\Nodes\BaseNode;
+use Stillat\BladeParser\Nodes\Components\ComponentNode;
+use Stillat\BladeParser\Nodes\Components\ParameterNode;
+use Stillat\BladeParser\Nodes\Components\ParameterType;
 use Stillat\BladeParser\Nodes\DirectiveNode;
 use Stillat\BladeParser\Nodes\EchoNode;
 use Stillat\BladeParser\Nodes\EchoType;
@@ -19,6 +22,12 @@ use Stillat\BladeParser\Nodes\LiteralNode;
 
 class InlineHtmlParser extends AbstractParser
 {
+    /**
+     * Component tag prefixes that pass PHP expressions in their parameters,
+     * next to the standard x- components the Blade parser handles natively.
+     */
+    protected const CUSTOM_COMPONENT_TAGS = ['flux', 'livewire'];
+
     protected $echoStrings = [
         '{!!' => '!!}',
         '{{{' => '}}}',
@@ -58,7 +67,8 @@ class InlineHtmlParser extends AbstractParser
         }
 
         $this->parseBladeContent(Document::fromText(
-            $this->replaceMultibyteChars($node->getText())
+            $this->replaceMultibyteChars($node->getText()),
+            customComponentTags: self::CUSTOM_COMPONENT_TAGS,
         ));
 
         if (count($this->items)) {
@@ -87,6 +97,10 @@ class InlineHtmlParser extends AbstractParser
 
             if ($child instanceof EchoNode) {
                 $this->parseEchoNode($child);
+            }
+
+            if ($child instanceof ComponentNode) {
+                $this->parseComponentNode($child);
             }
 
             $this->parseBladeContent($child);
@@ -166,6 +180,98 @@ class InlineHtmlParser extends AbstractParser
         $child->methodName = '@' . substr($child->methodName, mb_strlen($safetyPrefix));
 
         $this->items[] = $child;
+    }
+
+    protected function parseComponentNode(ComponentNode $node)
+    {
+        foreach ($node->parameters as $parameter) {
+            if ($parameter->value === '' || $parameter->valueNode?->position === null) {
+                continue;
+            }
+
+            $line = $parameter->valueNode->position->startLine;
+            $column = $this->parameterColumn($node, $parameter);
+
+            if ($parameter->type === ParameterType::DynamicVariable) {
+                $this->parseExpression($parameter->value, $line, $column);
+
+                continue;
+            }
+
+            foreach ($this->parameterEchoes($parameter->value) as [$content, $offset]) {
+                $this->parseExpression($content, $line, $column + $offset);
+            }
+        }
+    }
+
+    /**
+     * Stillat v2.1 reports parameter positions relative to a normalized tag
+     * (ComponentParser::getRelativeContentOffset): custom component tags are
+     * shifted left by their prefix length ($node->componentPrefix holds the
+     * prefix without the colon, e.g. "flux"), and paired standard tags are
+     * off by one against their self-closing form. Shift the column back.
+     */
+    protected function parameterColumn(ComponentNode $node, ParameterNode $parameter): int
+    {
+        return $parameter->valueNode->position->startColumn + match (true) {
+            $node->isCustomComponent => mb_strlen($node->componentPrefix),
+            $node->isSelfClosing     => 0,
+            default                  => 1,
+        };
+    }
+
+    protected function parameterEchoes(string $value): array
+    {
+        $echoStrings = $this->echoStrings;
+        uksort($echoStrings, fn ($a, $b) => mb_strlen($b) <=> mb_strlen($a));
+
+        $alternations = [];
+
+        foreach ($echoStrings as $prefix => $suffix) {
+            $alternations[] = preg_quote($prefix, '/') . '(.*?)' . preg_quote($suffix, '/');
+        }
+
+        // The lookbehind skips escaped echoes such as @{{ alpine }}.
+        preg_match_all(
+            '/(?<!@)(?:' . implode('|', $alternations) . ')/s',
+            $value,
+            $matches,
+            PREG_OFFSET_CAPTURE | PREG_SET_ORDER,
+        );
+
+        $echoes = [];
+
+        foreach ($matches as $match) {
+            foreach (array_slice($match, 1) as $capture) {
+                if (($capture[1] ?? -1) !== -1) {
+                    $echoes[] = [$capture[0], $capture[1]];
+                }
+            }
+        }
+
+        return $echoes;
+    }
+
+    protected function parseExpression(string $content, int $line, int $column)
+    {
+        $snippet = "<?php\n" . str_repeat(' ', $column) . $content . ';';
+
+        $sourceFile = (new Parser)->parseSourceFile($snippet);
+
+        Settings::$calculatePosition = function (Range $range) use ($line) {
+            $range->start->line += $this->startLine + $line - 2;
+            $range->end->line += $this->startLine + $line - 2;
+
+            return $range;
+        };
+
+        $result = Parse::parse($sourceFile);
+
+        if (count($result->children) === 0) {
+            return;
+        }
+
+        $this->items[] = $result->children[0];
     }
 
     protected function parseEchoNode(EchoNode $node)

--- a/tests/Unit/DetectTest.php
+++ b/tests/Unit/DetectTest.php
@@ -564,3 +564,138 @@ test('extract functions and string params', function () {
 
     ]));
 });
+
+test('extract component parameter expressions', function () {
+    $blade = <<<'BLADE'
+    <x-button :href="route('reports.index')" />
+    <x-button :href="route('reports.index')">Reports</x-button>
+    <flux:button :href="route('reports.show', $report)">Show</flux:button>
+    <x-input placeholder="{{ __('reports.search') }}" />
+    BLADE;
+
+    $walker = new DetectWalker($blade);
+
+    expect($walker->walk()->toJson(JSON_PRETTY_PRINT))->toBe(detect([
+        [
+            'type'       => 'methodCall',
+            'methodName' => 'route',
+            'className'  => null,
+            'arguments'  => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'reports.index',
+                                'start' => [
+                                    'line'   => 0,
+                                    'column' => 23,
+                                ],
+                                'end' => [
+                                    'line'   => 0,
+                                    'column' => 36,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        [
+            'type'       => 'methodCall',
+            'methodName' => 'route',
+            'className'  => null,
+            'arguments'  => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'reports.index',
+                                'start' => [
+                                    'line'   => 1,
+                                    'column' => 23,
+                                ],
+                                'end' => [
+                                    'line'   => 1,
+                                    'column' => 36,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        [
+            'type'       => 'methodCall',
+            'methodName' => 'route',
+            'className'  => null,
+            'arguments'  => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 2,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'reports.show',
+                                'start' => [
+                                    'line'   => 2,
+                                    'column' => 26,
+                                ],
+                                'end' => [
+                                    'line'   => 2,
+                                    'column' => 38,
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [],
+                    ],
+                ],
+            ],
+        ],
+        [
+            'type'       => 'methodCall',
+            'methodName' => '__',
+            'className'  => null,
+            'arguments'  => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'reports.search',
+                                'start' => [
+                                    'line'   => 3,
+                                    'column' => 28,
+                                ],
+                                'end' => [
+                                    'line'   => 3,
+                                    'column' => 42,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]));
+});


### PR DESCRIPTION
PHP expressions inside Blade component parameters are currently invisible to the parser, so none of the Laravel features (routes, translations, config, views) work there. `<x-button :href="route('reports.index')">` and `<flux:button :href="route('reports.show', $report)">` produce no go-to-definition, hover, or diagnostics, while the same calls in `{{ }}` echoes work. On a Livewire + Flux codebase that is most of the `route()` usage in Blade.

This PR teaches `InlineHtmlParser` to parse two parameter shapes on component tags:

- `:attr="expression"` (`ParameterType::DynamicVariable`)
- `attr="{{ expression }}"` and the other echo types (`ParameterType::InterpolatedValue`), reusing the existing `$echoStrings` map and skipping escaped `@{{ }}` echoes

`flux` and `livewire` are registered as custom component tags with the Stillat parser (`CUSTOM_COMPONENT_TAGS` constant), so their parameters are parsed the same way as standard `x-` components. Bound attributes on plain HTML tags are untouched — those are Alpine expressions, not PHP.

Two notes for review:

- **Column compensation.** Stillat v2.1 reports parameter positions relative to a normalized tag (`ComponentParser::getRelativeContentOffset`): custom component tags are shifted left by their prefix length, and paired standard tags are off by one against their self-closing form. `parameterColumn()` shifts the column back and documents this with the version pinned. Happy to file this upstream at stillat/blade-parser if you agree it's a defect.
- **`parseExpression()` overlaps `doEchoParse()`.** Same snippet construction and parse flow, differing in position math (column-based versus indentation-plus-prefix). I kept them separate to avoid touching the battle-tested echo path in an outside PR; merging them is a possible follow-up.

Added a test to `tests/Unit/DetectTest.php` pinning exact line/column output for four cases: self-closing native, paired native, paired custom prefix with a second argument, and an interpolated value. The Blade content is inlined because `/tests/snippets` is in `.gitignore`, which currently makes the 19 fixture-based tests fail on a fresh clone (the existing `DetectTest` expectations also predate the current `methodName`/`className`/`arguments` serializer shape, so restoring fixtures alone won't turn them green — separate issue material).

Verified against a production Livewire + Flux app: all previously-dead `:href="route(...)"` sites resolve with exact positions, the full-suite failure set is byte-identical to a clean checkout, and Pint passes.
