### PR TITLE
Document Claude Code plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Install and configure the official [Laravel VS Code extension](https://github.co
 
 Install and configure the official [Laravel VS Code extension](https://github.com/laravel/vs-code-extension), which is compatible with Cursor.
 
+### Claude Code
+
+Install the official [Laravel LSP plugin](https://github.com/laravel/agent-skills) from the Laravel plugin marketplace:
+
+```
+/plugin marketplace add laravel/agent-skills
+/plugin install laravel-lsp@laravel
+```
+
 ### Neovim
 
 Neovim 0.11+ is required. Add a custom LSP configuration:


### PR DESCRIPTION
Adds Claude Code to the editor list, matching the existing per-editor sections. Boost registers this language server with Claude Code's LSP tool through a project plugin, so the section points at `boost:install` rather than hand-written config.

Draft until laravel/boost#905 lands — if the flag or flow changes in review there, this section follows.