### PR TITLE
Remove unused single-channel logging setup

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,9 +36,24 @@ class AppServiceProvider extends ServiceProvider
         }
 
         File::ensureDirectoryExists(
-            $dir = dirname(Phar::running(false)) . '/logs'
+            $dir = $this->getCompiledLoggingDirectory()
         );
 
         return $dir . '/lsp.log';
+    }
+
+    /**
+     * Get the logging directory when running as a compiled binary.
+     */
+    protected function getCompiledLoggingDirectory(): string
+    {
+        $dir = dirname(Phar::running(false)) . '/logs';
+        $dirIsWritable = is_dir($dir) ? is_writable($dir) : is_writable(dirname($dir));
+
+        if ($dirIsWritable) {
+            return $dir;
+        }
+
+        return sys_get_temp_dir() . '/laravel-lsp/logs';
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -31,29 +31,24 @@ class AppServiceProvider extends ServiceProvider
      */
     protected function getLoggingPath(): string
     {
-        if (!Phar::running()) {
-            return storage_path('logs/lsp.log');
+        $dir = Phar::running()
+            ? dirname(Phar::running(false)) . '/logs'
+            : storage_path('logs');
+
+        if (!$this->isWritableLoggingDirectory($dir)) {
+            $dir = sys_get_temp_dir() . '/laravel-lsp/logs';
         }
 
-        File::ensureDirectoryExists(
-            $dir = $this->getCompiledLoggingDirectory()
-        );
+        File::ensureDirectoryExists($dir);
 
         return $dir . '/lsp.log';
     }
 
     /**
-     * Get the logging directory when running as a compiled binary.
+     * Determine if logs can be written to the given directory.
      */
-    protected function getCompiledLoggingDirectory(): string
+    protected function isWritableLoggingDirectory(string $dir): bool
     {
-        $dir = dirname(Phar::running(false)) . '/logs';
-        $dirIsWritable = is_dir($dir) ? is_writable($dir) : is_writable(dirname($dir));
-
-        if ($dirIsWritable) {
-            return $dir;
-        }
-
-        return sys_get_temp_dir() . '/laravel-lsp/logs';
+        return is_dir($dir) ? is_writable($dir) : is_writable(dirname($dir));
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,53 +2,15 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
-use Phar;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap any application services.
-     */
-    public function boot(): void
-    {
-        config([
-            'logging.channels.single.path' => $this->getLoggingPath(),
-        ]);
-    }
-
     /**
      * Register any application services.
      */
     public function register(): void
     {
         //
-    }
-
-    /**
-     * Get logging path.
-     */
-    protected function getLoggingPath(): string
-    {
-        $dir = Phar::running()
-            ? dirname(Phar::running(false)) . '/logs'
-            : storage_path('logs');
-
-        if (!$this->isWritableLoggingDirectory($dir)) {
-            $dir = sys_get_temp_dir() . '/laravel-lsp/logs';
-        }
-
-        File::ensureDirectoryExists($dir);
-
-        return $dir . '/lsp.log';
-    }
-
-    /**
-     * Determine if logs can be written to the given directory.
-     */
-    protected function isWritableLoggingDirectory(string $dir): bool
-    {
-        return is_dir($dir) ? is_writable($dir) : is_writable(dirname($dir));
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,14 @@ use Illuminate\Support\ServiceProvider;
 class AppServiceProvider extends ServiceProvider
 {
     /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+
+    /**
      * Register any application services.
      */
     public function register(): void


### PR DESCRIPTION
Laravel LSP uses `stderr` as its default logging channel, but `AppServiceProvider` still eagerly configured the unused single channel and created a logs directory next to the compiled binary.

This caused the LSP to fail during startup when installed in a read-only location.

This change removes the eager logging-path configuration entirely.

fixes https://github.com/laravel/lsp/pull/47