### PR TITLE
Fix the "Array to string conversion" exception in Livewire/Blade component hovers and improve formatting for other default values

### DIFF
--- a/app/Lsp/Data/Templates/blade-components.php
+++ b/app/Lsp/Data/Templates/blade-components.php
@@ -49,7 +49,13 @@ $components = new class
             return $codeBlock;
         }
 
-        return $props->values()->filter()->flatMap(fn ($i) => $i);
+        return $props->values()
+            ->filter()
+            ->flatMap(fn ($i) => $i)
+            ->map(fn ($i) => array_key_exists('default', $i)
+                ? array_merge($i, ['default' => LspHelper::formatDefaultValue($i['default'])])
+                : $i
+            );
     }
 
     protected function getStandardViews()

--- a/app/Lsp/Data/Templates/blade-components.php
+++ b/app/Lsp/Data/Templates/blade-components.php
@@ -128,15 +128,14 @@ $components = new class
             $reflection = new ReflectionClass($class);
             $parameters = collect($reflection->getConstructor()?->getParameters() ?? [])
                 ->filter(fn ($p) => $p->isPromoted())
-                ->flatMap(fn ($p) => [$p->getName() => $p->isOptional() ? $this->normalizeDefault($p->getDefaultValue()) : null])
-                ->all();
+                ->keyBy(fn ($p) => $p->getName());
 
             $props = collect($reflection->getProperties())
                 ->filter(fn ($p) => $p->isPublic() && $p->getDeclaringClass()->getName() === $class)
                 ->map(fn ($p) => [
-                    'name'    => Str::kebab($p->getName()),
-                    'type'    => (string) ($p->getType() ?? 'mixed'),
-                    'default' => $this->normalizeDefault($p->getDefaultValue() ?? $parameters[$p->getName()] ?? null),
+                    'name' => Str::kebab($p->getName()),
+                    'type' => (string) ($p->getType() ?? 'mixed'),
+                    ...LspHelper::propertyDefault($p, $parameters->get($p->getName())),
                 ]);
 
             [$except, $props] = $props->partition(fn ($p) => $p['name'] === 'except');
@@ -309,17 +308,6 @@ $components = new class
         }
 
         return $components;
-    }
-
-    protected function normalizeDefault($value)
-    {
-        if ($value instanceof UnitEnum) {
-            return $value instanceof BackedEnum
-                ? $value->value
-                : $value::class . '::' . $value->name;
-        }
-
-        return $value;
     }
 
     protected function getNamespacePath($classNamespace)

--- a/app/Lsp/Data/Templates/global.php
+++ b/app/Lsp/Data/Templates/global.php
@@ -15,4 +15,18 @@ class LspHelper
     {
         return str_contains($path, base_path('vendor'));
     }
+
+    public static function formatDefaultValue(mixed $value): mixed
+    {
+        return match (true) {
+            is_array($value) => 'array(...)',
+            $value instanceof UnitEnum => get_class($value) . '::' . $value->name,
+            $value instanceof Closure => 'Closure',
+            is_object($value) => get_class($value),
+            is_string($value) => var_export($value, true),
+            is_null($value) => 'null',
+            is_bool($value) => $value ? 'true' : 'false',
+            default => $value,
+        };
+    }
 }

--- a/app/Lsp/Data/Templates/global.php
+++ b/app/Lsp/Data/Templates/global.php
@@ -16,17 +16,30 @@ class LspHelper
         return str_contains($path, base_path('vendor'));
     }
 
+    public static function propertyDefault(ReflectionProperty $property, ?ReflectionParameter $parameter = null): array
+    {
+        if ($property->hasDefaultValue()) {
+            return ['default' => $property->getDefaultValue()];
+        }
+
+        if ($parameter?->isDefaultValueAvailable()) {
+            return ['default' => $parameter->getDefaultValue()];
+        }
+
+        return [];
+    }
+
     public static function formatDefaultValue(mixed $value): mixed
     {
         return match (true) {
-            is_array($value) => 'array(...)',
+            is_array($value)           => 'array(...)',
             $value instanceof UnitEnum => get_class($value) . '::' . $value->name,
-            $value instanceof Closure => 'Closure',
-            is_object($value) => get_class($value),
-            is_string($value) => var_export($value, true),
-            is_null($value) => 'null',
-            is_bool($value) => $value ? 'true' : 'false',
-            default => $value,
+            $value instanceof Closure  => 'Closure',
+            is_object($value)          => get_class($value),
+            is_string($value)          => var_export($value, true),
+            is_null($value)            => 'null',
+            is_bool($value)            => $value ? 'true' : 'false',
+            default                    => $value,
         };
     }
 }

--- a/app/Lsp/Data/Templates/views.php
+++ b/app/Lsp/Data/Templates/views.php
@@ -115,23 +115,9 @@ $livewire = new class
                 'name'            => $prop,
                 'type'            => (string) $reflection->getType() ?: 'mixed',
                 'hasDefaultValue' => $reflection->hasDefaultValue(),
-                'defaultValue'    => $this->formatDefaultValue($reflection->getDefaultValue()),
+                'defaultValue'    => LspHelper::formatDefaultValue($reflection->getDefaultValue()),
             ];
         }, array_keys($component->all()));
-    }
-
-    protected function formatDefaultValue(mixed $value): mixed
-    {
-        return match (true) {
-            is_array($value) => 'array(...)',
-            $value instanceof UnitEnum => get_class($value) . '::' . $value->name,
-            $value instanceof Closure => 'Closure',
-            is_object($value) => get_class($value),
-            is_string($value) => var_export($value, true),
-            is_null($value) => 'null',
-            is_bool($value) => $value ? 'true' : 'false',
-            default => $value,
-        };
     }
 
     protected function key(array $view): string

--- a/app/Lsp/Data/Templates/views.php
+++ b/app/Lsp/Data/Templates/views.php
@@ -120,9 +120,18 @@ $livewire = new class
         }, array_keys($component->all()));
     }
 
-    protected function formatDefaultValue(mixed $value)
+    protected function formatDefaultValue(mixed $value): mixed
     {
-        return is_string($value) ? "'{$value}'" : $value;
+        return match (true) {
+            is_array($value) => 'array(...)',
+            $value instanceof UnitEnum => get_class($value) . '::' . $value->name,
+            $value instanceof Closure => 'Closure',
+            is_object($value) => get_class($value),
+            is_string($value) => var_export($value, true),
+            is_null($value) => 'null',
+            is_bool($value) => $value ? 'true' : 'false',
+            default => $value,
+        };
     }
 
     protected function key(array $view): string


### PR DESCRIPTION
Before:

<img width="1162" height="586" alt="obraz" src="https://github.com/user-attachments/assets/c92de7ac-9e57-4b2c-884d-90d5de0d982f" />

After:

<img width="832" height="390" alt="obraz" src="https://github.com/user-attachments/assets/a0b48fce-e66b-4cc0-9957-956c1ecdfe4d" />
