### PR TITLE
docs: gate Neovim config on artisan so the server only starts in Laravel projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,19 @@ Neovim 0.11+ is required. Add a custom LSP configuration:
 vim.lsp.config("laravel_lsp", {
     cmd = { "laravel-lsp" },
     filetypes = { "php", "blade" },
-    root_markers = { "artisan", "composer.json", ".git" },
+    root_dir = function(bufnr, on_dir)
+        local root = vim.fs.root(bufnr, "artisan")
+
+        if root then
+            on_dir(root)
+        end
+    end,
 })
 
 vim.lsp.enable("laravel_lsp")
 ```
+
+The `root_dir` callback only starts the server when an `artisan` file is found, so the server is not launched for PHP projects that are not Laravel applications.
 
 ### OpenCode
 


### PR DESCRIPTION
The Neovim configuration in the README uses `root_markers = { "artisan", "composer.json", ".git" }`. Since `composer.json` and `.git` match virtually any PHP project, Neovim launches `laravel-lsp` when opening PHP files in non-Laravel projects. The server's initialize handler then rejects the root, and the user sees this error on every buffer attach:

```
Error executing vim.schedule lua callback: .../lua/vim/lsp/client.lua:545: RPC[Error]
code_name = InvalidParams, message = "Initialize request root URI must be a Laravel project."
```

This PR updates the snippet to use a `root_dir` callback gated on the `artisan` file, so the server is simply never started outside Laravel projects — matching the server's own project detection in `Initialize.php`.

A callback is used rather than `root_markers = { "artisan" }` because when no marker matches, Neovim can still start the server in single-file mode with a nil root, which fails the same initialize check. With the callback, `on_dir` is never invoked and the server never launches.

Tested on Neovim 0.11.6: Laravel projects attach as before; non-Laravel PHP projects no longer produce the error.