### PR TITLE
Support for multi root workspaces

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -52,7 +52,6 @@ jobs:
           chmod +x ./builds/laravel-lsp
           VERSION=$(./builds/laravel-lsp --version)
           echo "$VERSION"
-          [[ "$VERSION" == *"${{ github.ref_name }}"* ]]
           ./builds/laravel-lsp list
 
       - name: Download PHP

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -52,6 +52,7 @@ jobs:
           chmod +x ./builds/laravel-lsp
           VERSION=$(./builds/laravel-lsp --version)
           echo "$VERSION"
+          [[ "$VERSION" == *"${{ github.ref_name }}"* ]]
           ./builds/laravel-lsp list
 
       - name: Download PHP

--- a/app/Lsp/Exceptions/ProjectNotFoundException.php
+++ b/app/Lsp/Exceptions/ProjectNotFoundException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Lsp\Exceptions;
+
+use App\Lsp\Contracts\Responsable;
+use App\Lsp\Transport\JsonRpcRequest;
+use App\Lsp\Transport\JsonRpcResponse;
+use Exception;
+
+class ProjectNotFoundException extends Exception implements Responsable
+{
+    /**
+     * Instantiate a new class instance.
+     */
+    public function __construct(public readonly ?string $uri = null)
+    {
+        parent::__construct('Project not found.');
+    }
+
+    /**
+     * Create a JSON-RPC response that represents the object.
+     */
+    public function toResponse(JsonRpcRequest $request): JsonRpcResponse
+    {
+        return JsonRpcResponse::error($request->id(), -32602, $this->getMessage(), ['uri' => $this->uri]);
+    }
+}

--- a/app/Lsp/Listeners/RegisterFileWatchers.php
+++ b/app/Lsp/Listeners/RegisterFileWatchers.php
@@ -7,6 +7,7 @@ namespace App\Lsp\Listeners;
 use App\Lsp\Contracts\Listener;
 use App\Lsp\FeatureRegistry;
 use App\Lsp\Project;
+use App\Lsp\Projects;
 use App\Lsp\Server;
 use App\Lsp\Transport\JsonRpcRequest;
 
@@ -18,7 +19,7 @@ class RegisterFileWatchers implements Listener
     public function __construct(
         protected Server $server,
         protected FeatureRegistry $features,
-        protected Project $project,
+        protected Projects $projects,
     ) {}
 
     /**
@@ -32,17 +33,26 @@ class RegisterFileWatchers implements Listener
                     'id' => 'file-watching',
                     'method' => 'workspace/didChangeWatchedFiles',
                     'registerOptions' => [
-                        'watchers' => array_map(fn (string $pattern) => [
-                            'globPattern' => [
-                                'baseUri' => $this->project->uri,
-                                'pattern' => $pattern,
-                            ],
-                            'kind' => 7,
-                        ], $this->patterns()),
+                        'watchers' => $this->projects
+                            ->collect()
+                            ->flatMap($this->watchers(...))
+                            ->values()
+                            ->all(),
                     ],
                 ],
             ],
         ]);
+    }
+
+    protected function watchers(Project $project): array
+    {
+        return array_map(fn (string $pattern) => [
+            'globPattern' => [
+                'baseUri' => $project->uri,
+                'pattern' => $pattern,
+            ],
+            'kind' => 7,
+        ], $this->patterns());
     }
 
     /**

--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -6,9 +6,12 @@ namespace App\Lsp\Methods;
 
 use App\Lsp\Contracts\ExceptionHandler;
 use App\Lsp\Contracts\Method;
+use App\Lsp\Exceptions\ProjectNotFoundException;
 use App\Lsp\PhpCommandDetector;
 use App\Lsp\Project;
+use App\Lsp\ProjectContext;
 use App\Lsp\ProjectIndex;
+use App\Lsp\Projects;
 use App\Lsp\ScriptRunner;
 use App\Lsp\Support\FileUri;
 use App\Lsp\Transport\JsonRpcRequest;
@@ -24,6 +27,7 @@ final class Initialize implements Method
     public function __construct(
         protected Container $container,
         protected LoggerInterface $logger,
+        protected ProjectContext $context,
     ) {}
 
     /**
@@ -31,28 +35,50 @@ final class Initialize implements Method
      */
     public function handle(JsonRpcRequest $request): JsonRpcResponse
     {
-        $rootUri = $request->get('rootUri');
+        $this->container->singleton(Projects::class);
 
-        if (!is_string($rootUri) || $rootUri === '') {
-            return JsonRpcResponse::error($request->id(), -32602, 'Initialize request must include a workspace root URI.');
+        $projects = [];
+
+        $workspaceFolders = $request->array('workspaceFolders') ?? [
+            ['uri' => $request->get('rootUri')]
+        ];
+
+        foreach ($workspaceFolders as $workspaceFolder) {
+            $rootUri = $workspaceFolder['uri'] ?? null;
+
+            if (!is_string($rootUri) || $rootUri === '') {
+                continue;
+            }
+
+            $uri = FileUri::of($rootUri);
+
+            if (!file_exists($uri->path('artisan'))) {
+                continue;
+            }
+
+            $projects[] = new Project(
+                $uri,
+                $request->array('initializationOptions'),
+                new ProjectIndex($this->container),
+                new ScriptRunner($uri->path(), $this->phpCommand($request, $uri)),
+            );
         }
 
-        $uri = FileUri::of($rootUri);
-
-        if (!file_exists($uri->path('artisan'))) {
-            return JsonRpcResponse::error($request->id(), -32602, 'Initialize request root URI must be a Laravel project.');
+        if ($projects === []) {
+            return JsonRpcResponse::error($request->id(), -32602, 'Initialize request must include at least one Laravel project.');
         }
 
-        $this->container->singleton(Project::class);
+        $projects = new Projects(...$projects);
 
-        $project = new Project(
-            $uri,
-            $request->array('initializationOptions'),
-            new ProjectIndex($this->container),
-            new ScriptRunner($uri->path(), $this->phpCommand($request, $uri)),
-        );
+        $this->container->instance(Projects::class, $projects);
 
-        $this->container->instance(Project::class, $project);
+        try {
+            $project = $projects->get($request->get('rootUri'));
+        } catch (ProjectNotFoundException $e) {
+            return $e->toResponse($request);
+        }
+
+        $this->context->setDefault($project);
 
         $this->logger->info('Initialized Laravel LSP.', [
             'rootUri'               => (string) $project->uri,

--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -73,7 +73,7 @@ final class Initialize implements Method
         $this->container->instance(Projects::class, $projects);
 
         try {
-            $project = $projects->get($request->get('rootUri'));
+            $project = $projects->get($rootUri);
         } catch (ProjectNotFoundException $e) {
             return $e->toResponse($request);
         }

--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -72,11 +72,7 @@ final class Initialize implements Method
 
         $this->container->instance(Projects::class, $projects);
 
-        try {
-            $project = $projects->get($rootUri);
-        } catch (ProjectNotFoundException $e) {
-            return $e->toResponse($request);
-        }
+        $project = $projects->first();
 
         $this->context->setDefault($project);
 

--- a/app/Lsp/ProjectContext.php
+++ b/app/Lsp/ProjectContext.php
@@ -19,6 +19,14 @@ final class ProjectContext
         $this->current = new FiberLocal(static fn (): ?Project => null);
     }
 
+    public function setDefault(Project $project): void
+    {
+        $this->default = $project;
+    }
+
+    /**
+     * Run the given callback within the context of the given project.
+     */
     public function run(?Project $project, Closure $callback): mixed
     {
         $this->current->set($project);
@@ -30,11 +38,11 @@ final class ProjectContext
         }
     }
 
-    public function setDefault(Project $project): void
-    {
-        $this->default = $project;
-    }
-
+    /**
+     * Get the current project.
+     *
+     * @throws ProjectNotFoundException if no project is set and no default project is available.
+     */
     public function current(): Project
     {
         return $this->current->get()

--- a/app/Lsp/ProjectContext.php
+++ b/app/Lsp/ProjectContext.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp;
+
+use App\Lsp\Exceptions\ProjectNotFoundException;
+use Closure;
+use Revolt\EventLoop\FiberLocal;
+
+final class ProjectContext
+{
+    private FiberLocal $current;
+
+    private ?Project $default = null;
+
+    public function __construct()
+    {
+        $this->current = new FiberLocal(static fn (): ?Project => null);
+    }
+
+    public function run(?Project $project, Closure $callback): mixed
+    {
+        $this->current->set($project);
+
+        try {
+            return $callback();
+        } finally {
+            $this->current->unset();
+        }
+    }
+
+    public function setDefault(Project $project): void
+    {
+        $this->default = $project;
+    }
+
+    public function current(): Project
+    {
+        return $this->current->get()
+            ?? $this->default
+            ?? throw new ProjectNotFoundException;
+    }
+}

--- a/app/Lsp/Projects.php
+++ b/app/Lsp/Projects.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp;
+
+use App\Lsp\Exceptions\ProjectNotFoundException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+final class Projects
+{
+    /** @var Project[] */
+    private readonly array $projects;
+
+    public function __construct(Project ...$projects)
+    {
+        $this->projects = $projects;
+    }
+
+    /**
+     * Get the project that contains the given URI.
+     *
+     * @throws ProjectNotFoundException if no project is found for the given URI.
+     */
+    public function get(string $uri): Project
+    {
+        return Arr::first(
+            $this->projects,
+            fn (Project $project) => Str::startsWith($uri, (string) $project->uri)
+        ) ?? throw new ProjectNotFoundException($uri);
+    }
+}

--- a/app/Lsp/Projects.php
+++ b/app/Lsp/Projects.php
@@ -5,17 +5,36 @@ declare(strict_types=1);
 namespace App\Lsp;
 
 use App\Lsp\Exceptions\ProjectNotFoundException;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 final class Projects
 {
-    /** @var Collection<int, Project> */
-    private readonly Collection $projects;
+    /** @var array<int, Project> */
+    private readonly array $projects;
 
     public function __construct(Project ...$projects)
     {
-        $this->projects = collect($projects);
+        $this->projects = $projects;
+    }
+
+    /**
+     * Get all projects as a collection.
+     *
+     * @return Collection<int, Project>
+     */
+    public function collect(): Collection
+    {
+        return collect($this->projects);
+    }
+
+    /**
+     * Get first project in the collection.
+     */
+    public function first(): Project
+    {
+        return Arr::first($this->projects);
     }
 
     /**
@@ -25,7 +44,8 @@ final class Projects
      */
     public function get(string $uri): Project
     {
-        return $this->projects
+        return $this
+            ->collect()
             ->sortByDesc(fn (Project $project): int => strlen((string) $project->uri))
             ->first(fn (Project $project): bool => $this->containsUri($project, $uri))
             ?? throw new ProjectNotFoundException($uri);

--- a/app/Lsp/Projects.php
+++ b/app/Lsp/Projects.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace App\Lsp;
 
 use App\Lsp\Exceptions\ProjectNotFoundException;
-use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 final class Projects
 {
-    /** @var Project[] */
-    private readonly array $projects;
+    /** @var Collection<int, Project> */
+    private readonly Collection $projects;
 
     public function __construct(Project ...$projects)
     {
-        $this->projects = $projects;
+        $this->projects = collect($projects);
     }
 
     /**
@@ -25,9 +25,18 @@ final class Projects
      */
     public function get(string $uri): Project
     {
-        return Arr::first(
-            $this->projects,
-            fn (Project $project) => Str::startsWith($uri, (string) $project->uri)
-        ) ?? throw new ProjectNotFoundException($uri);
+        return $this->projects
+            ->sortByDesc(fn (Project $project): int => strlen((string) $project->uri))
+            ->first(fn (Project $project): bool => $this->containsUri($project, $uri))
+            ?? throw new ProjectNotFoundException($uri);
+    }
+
+    /**
+     * Determine whether the given project contains the URI.
+     */
+    protected function containsUri(Project $project, string $uri): bool
+    {
+        return $uri === (string) $project->uri
+            || Str::startsWith($uri, Str::finish((string) $project->uri, '/'));
     }
 }

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -159,10 +159,7 @@ final class Server
 
         $this->transport->dispatch(
             $request,
-            fn (JsonRpcRequest $request) => $this->context->run(
-                $project,
-                fn () => $this->dispatch($request),
-            ),
+            fn (JsonRpcRequest $request) => $this->dispatchInProjectContext($request, $project),
         );
     }
 
@@ -267,6 +264,14 @@ final class Server
     public function dispatchRequest(JsonRpcRequest $request): void
     {
         $this->respond($this->handleRequest($request));
+    }
+
+    /**
+     * Dispatch the request in the context of the given project.
+     */
+    protected function dispatchInProjectContext(JsonRpcRequest $request, ?Project $project): mixed
+    {
+        return $this->context->run($project, fn () => $this->dispatch($request));
     }
 
     /**

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -384,7 +384,7 @@ final class Server
      */
     protected function resolveProject(JsonRpcRequest $request): ?Project
     {
-        $uri = $request->get('textDocument.uri');
+        $uri = $request->uri();
 
         if ($uri === null) {
             return null;

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -12,7 +12,7 @@ use App\Lsp\Exceptions\Handler;
 use App\Lsp\Exceptions\InvalidRequestException;
 use App\Lsp\Exceptions\MethodNotFoundException;
 use App\Lsp\Exceptions\ParseException;
-use App\Lsp\Exceptions\ServerNotInitializedException;
+use App\Lsp\Exceptions\ProjectNotFoundException;
 use App\Lsp\Listeners\CancelRequest;
 use App\Lsp\Listeners\ClearDocumentDiagnostics;
 use App\Lsp\Listeners\CloseDocument;
@@ -92,6 +92,7 @@ final class Server
         protected Transport $transport,
         protected LoggerInterface $logger = new NullLogger,
         protected Container $container = new Container,
+        protected ProjectContext $context = new ProjectContext,
     ) {
         $this->registerBaseBindings();
     }
@@ -148,7 +149,21 @@ final class Server
             return;
         }
 
-        $this->transport->dispatch($request, $this->dispatch(...));
+        try {
+            $project = $this->resolveProject($request);
+        } catch (ProjectNotFoundException $e) {
+            $this->cancel($request->id());
+
+            return;
+        }
+
+        $this->transport->dispatch(
+            $request,
+            fn (JsonRpcRequest $request) => $this->context->run(
+                $project,
+                fn () => $this->dispatch($request),
+            ),
+        );
     }
 
     /**
@@ -339,15 +354,39 @@ final class Server
      */
     protected function registerBaseBindings(): void
     {
+        $this->container->singleton(ProjectContext::class);
+
         $this->container->instance(Container::class, $this->container);
         $this->container->instance(Server::class, $this);
         $this->container->instance(Transport::class, $this->transport);
         $this->container->instance(LoggerInterface::class, $this->logger);
+        $this->container->instance(ProjectContext::class, $this->context);
+
+        $this->container->bind(
+            Project::class,
+            fn (): Project => $this->context->current(),
+        );
 
         $this->container->singletonIf(DocumentManager::class);
         $this->container->singletonIf(ExceptionHandler::class, Handler::class);
 
-        $this->container->singletonIf(Project::class, fn () => throw new ServerNotInitializedException);
+        $this->container->singletonIf(Projects::class, fn () => new Projects());
         $this->container->singletonIf(FeatureRegistry::class);
+    }
+
+    /**
+     * Resolve the project for the given request.
+     */
+    protected function resolveProject(JsonRpcRequest $request): ?Project
+    {
+        $uri = $request->get('textDocument.uri');
+
+        if ($uri === null) {
+            return null;
+        }
+
+        $projects = $this->container->make(Projects::class);
+
+        return $projects->get($uri);
     }
 }

--- a/app/Lsp/Transport/JsonRpcRequest.php
+++ b/app/Lsp/Transport/JsonRpcRequest.php
@@ -6,10 +6,10 @@ namespace App\Lsp\Transport;
 
 use Amp\Cancellation;
 use App\Lsp\Exceptions\RequestCancelledException;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Traits\InteractsWithData;
-
 use function Amp\delay;
+use Illuminate\Support\Arr;
+
+use Illuminate\Support\Traits\InteractsWithData;
 
 class JsonRpcRequest
 {
@@ -75,6 +75,17 @@ class JsonRpcRequest
     public function method(): string
     {
         return $this->method;
+    }
+
+    /**
+     * Get the URI which the request/notification is related to.
+     */
+    public function uri(): ?string
+    {
+        return match ($this->method) {
+            'workspace/didChangeWatchedFiles' => $this->get('changes.0.uri'),
+            default => $this->get('textDocument.uri'),
+        };
     }
 
     /**

--- a/tests/Unit/ProjectsTest.php
+++ b/tests/Unit/ProjectsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Lsp\Exceptions\ProjectNotFoundException;
+use App\Lsp\Project;
+use App\Lsp\ProjectIndex;
+use App\Lsp\Projects;
+use App\Lsp\ScriptRunner;
+use App\Lsp\Support\FileUri;
+use Illuminate\Container\Container;
+
+function makeProject(string $uri): Project
+{
+    return new Project(
+        FileUri::of($uri),
+        [],
+        new ProjectIndex(new Container),
+        new ScriptRunner('', []),
+    );
+}
+
+test('gets the project with the longest matching URI', function () {
+    $firstProject = makeProject('file:///my-first-project');
+    $secondProject = makeProject('file:///my-first-project-and-something-else');
+
+    $projects = new Projects($firstProject, $secondProject);
+
+    expect($projects->get('file:///my-first-project-and-something-else/my-file.php'))
+        ->toBe($secondProject);
+});
+
+test('gets the most specific project when projects are nested', function () {
+    $parentProject = makeProject('file:///projects');
+    $nestedProject = makeProject('file:///projects/application');
+
+    $projects = new Projects($nestedProject, $parentProject);
+
+    expect($projects->get('file:///projects/application/app/Models/User.php'))
+        ->toBe($nestedProject);
+});
+
+test('gets a project when URI matches exactly', function () {
+    $project = makeProject('file:///projects/application');
+
+    $projects = new Projects($project);
+
+    expect($projects->get('file:///projects/application'))
+        ->toBe($project);
+});
+
+test('does not match a project URI that is only a path prefix', function () {
+    $project = makeProject('file:///my-first-project');
+
+    $projects = new Projects($project);
+
+    expect(fn () => $projects->get('file:///my-first-project-archive/my-file.php'))
+        ->toThrow(ProjectNotFoundException::class);
+});


### PR DESCRIPTION
This PR adds support for multi-root workspaces in the LSP version, similar to my previous PR for native VS Code support: https://github.com/laravel/vs-code-extension/pull/624.

I tried to keep the changes to a minimum, so this implementation uses `FiberLocal` to store the current project for each request. This ensures that every asynchronous request has its own project context and does not overwrite the context of another request being processed in parallel. The project is still bound to the service container as before.

I have only tested this in VS Code on Linux, so any feedback would be greatly appreciated.

VSCode depends on client part https://github.com/laravel/vs-code-extension/pull/690