### PR TITLE
Initialize file watchers after registering them

### DIFF
--- a/app/Lsp/Listeners/RegisterFileWatchers.php
+++ b/app/Lsp/Listeners/RegisterFileWatchers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Lsp\Listeners;
 
+use App\Lsp\Contracts\FileWatcher;
 use App\Lsp\Contracts\Listener;
 use App\Lsp\FeatureRegistry;
 use App\Lsp\Project;
@@ -26,6 +27,8 @@ class RegisterFileWatchers implements Listener
      */
     public function handle(JsonRpcRequest $request): void
     {
+        $watchers = $this->features->watchers();
+
         $this->server->send('client/registerCapability', [
             'registrations' => [
                 [
@@ -38,21 +41,28 @@ class RegisterFileWatchers implements Listener
                                 'pattern' => $pattern,
                             ],
                             'kind' => 7,
-                        ], $this->patterns()),
+                        ], $this->patterns($watchers)),
                     ],
                 ],
             ],
         ]);
+
+        foreach ($watchers as $watcher) {
+            $watcher->initialize();
+        }
     }
 
     /**
      * Collect watcher patterns.
+     *
+     * @param  array<int, FileWatcher>  $watchers
+     * @return array<int, string>
      */
-    protected function patterns(): array
+    protected function patterns(array $watchers): array
     {
         $patterns = [];
 
-        foreach ($this->features->watchers() as $watcher) {
+        foreach ($watchers as $watcher) {
             array_push($patterns, ...$watcher->patterns());
         }
 


### PR DESCRIPTION
`FileWatcher::initialize()` isn't called anywhere, so `PestHelperWatcher::initialize()` never runs. With `pestGenerateDocBlocks` on you get no helper file when the editor starts, it only shows up once you touch something matching `tests/**/*` or `vendor/composer/autoload_*.php`.

So `RegisterFileWatchers` now calls `initialize()` on each watcher after it sends the registration, which is the order `PestHelperWatcher::initialize()` already documents.

Checked it by driving the server over stdio against a Laravel app with Pest installed:

| | before | after |
|---|---|---|
| after `initialize` + `initialized` | nothing written | helper written |
| after `workspace/didChangeWatchedFiles` | helper written | helper written |

Two notes: `DataProviderWatcher::initialize()` is a no-op so nothing else changes. And the `patterns()` signature change is only there so the watchers get resolved once, `FeatureRegistry::watchers()` builds new instances on every call.
