### PR TITLE
Resolve relative paths under a symlinked project root

### DIFF
--- a/app/Lsp/Support/FileUri.php
+++ b/app/Lsp/Support/FileUri.php
@@ -52,7 +52,7 @@ class FileUri implements JsonSerializable
 
         return $line === null
             ? $target
-            : new self($target.'#L'.max(1, $line));
+            : new self($target . '#L' . max(1, $line));
     }
 
     /**
@@ -66,23 +66,47 @@ class FileUri implements JsonSerializable
             return $path;
         }
 
-        foreach ([$path, realpath($path) ?: null] as $candidate) {
-            if ($candidate === null) {
-                continue;
-            }
+        $normalized = self::normalizePath($path);
 
-            $normalized = self::normalizePath($candidate);
+        // The common case: the client sent a path in the same form the root was
+        // registered in, so neither side needs resolving.
+        if (($relative = self::relativeTo($normalized, $basePath)) !== null) {
+            return $relative;
+        }
 
-            if ($normalized === $basePath) {
-                return '';
-            }
+        // Otherwise the root, the path, or both may be reached through a symlink.
+        // Resolving one side is not enough, since either may be the symlinked one.
+        $basePaths = [$basePath];
 
-            if (str_starts_with($normalized, $basePath.'/')) {
-                return substr($normalized, strlen($basePath) + 1);
+        if (($resolvedBase = realpath($this->path())) !== false) {
+            $basePaths[] = rtrim(self::normalizePath($resolvedBase), '/');
+        }
+
+        if (($resolvedPath = realpath($path)) !== false) {
+            $normalized = self::normalizePath($resolvedPath);
+        }
+
+        foreach ($basePaths as $candidate) {
+            if (($relative = self::relativeTo($normalized, $candidate)) !== null) {
+                return $relative;
             }
         }
 
         return $path;
+    }
+
+    /**
+     * Get the given normalized path relative to a base path, if it is inside it.
+     */
+    protected static function relativeTo(string $path, string $basePath): ?string
+    {
+        if ($path === $basePath) {
+            return '';
+        }
+
+        return str_starts_with($path, $basePath . '/')
+            ? substr($path, strlen($basePath) + 1)
+            : null;
     }
 
     /**
@@ -106,7 +130,7 @@ class FileUri implements JsonSerializable
      */
     public static function fromPath(string $path): self
     {
-        return new self('file://'.self::encodePath($path));
+        return new self('file://' . self::encodePath($path));
     }
 
     /**
@@ -131,7 +155,7 @@ class FileUri implements JsonSerializable
         $path = str_replace('\\', '/', $path);
 
         if (preg_match('/^[A-Za-z]:(?:\/|$)/', $path) === 1) {
-            return strtoupper($path[0]).substr($path, 1);
+            return strtoupper($path[0]) . substr($path, 1);
         }
 
         return $path;
@@ -143,7 +167,7 @@ class FileUri implements JsonSerializable
     protected static function encodePath(string $path): string
     {
         $path = str_replace('\\', '/', $path);
-        $path = '/'.ltrim($path, '/');
+        $path = '/' . ltrim($path, '/');
 
         return implode('/', array_map('rawurlencode', explode('/', $path)));
     }

--- a/app/Lsp/Support/FileUri.php
+++ b/app/Lsp/Support/FileUri.php
@@ -61,17 +61,28 @@ class FileUri implements JsonSerializable
     public function relativePath(string $path): string
     {
         $basePath = rtrim(self::normalizePath($this->path()), '/');
-        $normalized = self::normalizePath(realpath($path) ?: $path);
 
-        if ($normalized === $basePath) {
-            return '';
-        }
-
-        if ($basePath === '' || !str_starts_with($normalized, $basePath.'/')) {
+        if ($basePath === '') {
             return $path;
         }
 
-        return substr($normalized, strlen($basePath) + 1);
+        foreach ([$path, realpath($path) ?: null] as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = self::normalizePath($candidate);
+
+            if ($normalized === $basePath) {
+                return '';
+            }
+
+            if (str_starts_with($normalized, $basePath.'/')) {
+                return substr($normalized, strlen($basePath) + 1);
+            }
+        }
+
+        return $path;
     }
 
     /**

--- a/tests/Unit/FileUriTest.php
+++ b/tests/Unit/FileUriTest.php
@@ -48,3 +48,25 @@ test('relative path returns an empty string for the base path itself', function 
 
     expect($uri->relativePath('D:\\a\\project\\project'))->toBe('');
 });
+
+test('relative path for a project root reached through a symlink', function () {
+    $real = sys_get_temp_dir() . '/lsp-symlink-real-' . getmypid();
+    $link = sys_get_temp_dir() . '/lsp-symlink-' . getmypid();
+
+    mkdir($real . '/config', 0777, true);
+    touch($real . '/config/app.php');
+
+    if (!@symlink($real, $link)) {
+        $this->markTestSkipped('Unable to create a symlink on this platform.');
+    }
+
+    try {
+        expect(FileUri::fromPath($link)->relativePath($link . '/config/app.php'))
+            ->toBe('config/app.php');
+    } finally {
+        @unlink($link);
+        @unlink($real . '/config/app.php');
+        @rmdir($real . '/config');
+        @rmdir($real);
+    }
+});

--- a/tests/Unit/FileUriTest.php
+++ b/tests/Unit/FileUriTest.php
@@ -70,3 +70,45 @@ test('relative path for a project root reached through a symlink', function () {
         @rmdir($real);
     }
 });
+
+test('relative path when the root is a symlink and the client sends the resolved path', function () {
+    $real = sys_get_temp_dir() . '/lsp-mirror-real-' . getmypid();
+    $link = sys_get_temp_dir() . '/lsp-mirror-link-' . getmypid();
+
+    mkdir($real . '/config', 0777, true);
+    touch($real . '/config/app.php');
+
+    if (!@symlink($real, $link)) {
+        $this->markTestSkipped('Unable to create a symlink on this platform.');
+    }
+
+    try {
+        $uri = FileUri::fromPath($link);
+
+        expect($uri->relativePath($real . '/config/app.php'))->toBe('config/app.php');
+        expect($uri->relativePath($real))->toBe('');
+    } finally {
+        @unlink($link);
+        @unlink($real . '/config/app.php');
+        @rmdir($real . '/config');
+        @rmdir($real);
+    }
+});
+
+test('relative path leaves a file outside the project untouched', function () {
+    $root = sys_get_temp_dir() . '/lsp-outside-root-' . getmypid();
+    $outside = sys_get_temp_dir() . '/lsp-outside-other-' . getmypid();
+
+    mkdir($root, 0777, true);
+    mkdir($outside, 0777, true);
+    touch($outside . '/x.php');
+
+    try {
+        expect(FileUri::fromPath($root)->relativePath($outside . '/x.php'))
+            ->toBe($outside . '/x.php');
+    } finally {
+        @unlink($outside . '/x.php');
+        @rmdir($outside);
+        @rmdir($root);
+    }
+});


### PR DESCRIPTION
`relativePath()` runs the incoming path through `realpath()` but not the base, so if the project root is reached through a symlink the two never line up and it hands back an absolute path.

That silently breaks invalidation, since the watcher patterns are relative:

| provider | before | after |
|---|---|---|
| configs | no match | match |
| translations | no match | match |
| models | no match | match |
| routes, views | match | match |

Routes and views keep working because their patterns start with `**/`, which is why it shows up as configs and translations going stale rather than the server looking broken.

It tries the path as given first and only falls back to `realpath()`, so the existing cases are untouched. Existing tests pass either way because their paths don't exist on disk, so `realpath()` never fires there, and I added one that does.
