### PR TITLE
Fix translation indexing for decorated translation loaders

### DIFF
--- a/app/Lsp/Data/Templates/translations.php
+++ b/app/Lsp/Data/Templates/translations.php
@@ -84,20 +84,10 @@ $translator = new class
         }
 
         if ($property !== null) {
-            $paths = Arr::wrap($property->getValue($loader));
-
-            if ($paths !== []) {
-                return $paths;
-            }
+            return Arr::wrap($property->getValue($loader));
         }
 
-        // A custom or decorated loader (a caching or database loader wrapping a
-        // FileLoader, for example) need not expose its filesystem paths, so fall back to
-        // the paths the framework itself uses.
-        return array_values(array_filter([
-            app()->langPath(),
-            resource_path('lang'),
-        ], 'is_dir'));
+        return [app()->langPath()];
     }
 
     public function collectFromPath(string $path, ?string $namespace = null)

--- a/app/Lsp/Data/Templates/translations.php
+++ b/app/Lsp/Data/Templates/translations.php
@@ -84,10 +84,20 @@ $translator = new class
         }
 
         if ($property !== null) {
-            return Arr::wrap($property->getValue($loader));
+            $paths = Arr::wrap($property->getValue($loader));
+
+            if ($paths !== []) {
+                return $paths;
+            }
         }
 
-        return [];
+        // A custom or decorated loader (a caching or database loader wrapping a
+        // FileLoader, for example) need not expose its filesystem paths, so fall back to
+        // the paths the framework itself uses.
+        return array_values(array_filter([
+            app()->langPath(),
+            resource_path('lang'),
+        ], 'is_dir'));
     }
 
     public function collectFromPath(string $path, ?string $namespace = null)


### PR DESCRIPTION
`getPaths()` reflects on `app('translator')->getLoader()` for a `paths` or `path`
property. That holds for `Illuminate\Translation\FileLoader`, but an application that
decorates or replaces the loader falls through to `return []`, so no lang file is
scanned and every first-party `trans()`/`__()` key is reported as missing.

Observed on a Laravel 12 app using `waavi/translation`, where the bound loader is a
caching decorator over `MixedLoader` → `DatabaseLoader` + `FileLoader`:

```
loader: App\Support\Translation\CacheLoader
has paths: false
has path:  false
props: cache, defaultLocale, fallback, cacheTimeout
```

`spatie/laravel-translation-loader` binds its own loader for the same reason and is
affected identically. The symptom is a `Translation [...] not found` diagnostic on every
call site in the project, including keys that plainly exist in `lang/`.

This falls back to the paths the framework itself uses when the loader exposes none.
Fallback rather than union, so an application that deliberately points its loader
somewhere else does not get phantom keys from a directory it never reads. Both
candidates are already what `Translations::patterns()` watches (`lang/{*,**/*}`,
`resources/lang/{*,**/*}`), so this aligns indexing with the existing watcher intent,
and the `is_dir` filter keeps the old-structure `resources/lang` from adding a
nonexistent path on a modern skeleton.

On the app above, this alone takes the index from 72 keys to 1668.

Two further defects in this file keep translations from working on such a project.
They are independent of this one and sent separately as #71 and #72; the three touch
different methods and do not conflict.
