### PR TITLE
Fix package translation indexing for unresolved lang paths

### DIFF
--- a/app/Lsp/Data/Templates/translations.php
+++ b/app/Lsp/Data/Templates/translations.php
@@ -103,7 +103,7 @@ $translator = new class
         }
 
         return array_map(
-            fn ($file) => $this->fromFile($file, $path, $namespace),
+            fn ($file) => $this->fromFile($file, $realPath, $namespace),
             File::allFiles($realPath),
         );
     }


### PR DESCRIPTION
`collectFromPath()` enumerates the resolved path but passes the *unresolved* one down:

```php
$realPath = realpath($path);
…
return array_map(
    fn ($file) => $this->fromFile($file, $path, $namespace),
    File::allFiles($realPath),
);
```

`fromPhpFile()` then derives the locale and the group by stripping `$path` off `$file`:

```php
$lang = str($file)->after($path . DIRECTORY_SEPARATOR)->before(DIRECTORY_SEPARATOR)->value();
$key  = str($file)->after($path . DIRECTORY_SEPARATOR)->after(DIRECTORY_SEPARATOR)->replaceLast('.php', '')->value();
```

When `$path !== $realPath`, `$path` is not a prefix of `$file`, so `Str::after()` returns
the whole subject unchanged. `$lang` comes out as `''` and `$key` as most of an absolute
filesystem path. `getDotted()` cannot resolve that key, `__()` returns the key string
rather than an array, and the `array_key_exists($key, $lines)` guard then drops every
entry — so the files are silently skipped rather than indexed under a wrong name.

This affects any package registering its lang path as `__DIR__ . '/../../resources/lang'`,
which is the common idiom, since `realpath()` collapses the `..` segments. It also
affects a symlinked vendor directory, which `realpath()` resolves too.

On a Laravel 12 app with 7 package namespaces, 6 contained a `..` segment and indexed
zero keys. The only one that worked registers an already-resolved path.

Keying off `$realPath` fixes it, since that is what the files were enumerated from.
On the app above, this alone takes the index from 72 keys to 307.

Distinct from #69, which addresses `FileUri::relativePath()` and watcher invalidation.
Independent of #70 and #72, which fix two other defects in this file; the three touch
different methods and do not conflict.
