### PR TITLE
Fix translation values falling back to the default locale

### DIFF
--- a/app/Lsp/Data/Templates/translations.php
+++ b/app/Lsp/Data/Templates/translations.php
@@ -355,7 +355,7 @@ $translator = new class
             'k'  => $key,
             'la' => $lang,
             'vs' => LazyCollection::make(function () use ($key, $lang, $relativePath, $lines) {
-                foreach ($this->getDotted($key, [], $lang) as $key => $value) {
+                foreach ($this->getDotted($key, $lang) as $key => $value) {
                     if (!array_key_exists($key, $lines) || is_array($value)) {
                         continue;
                     }


### PR DESCRIPTION
`fromPhpFile()` calls `getDotted()` with three arguments:

```php
foreach ($this->getDotted($key, [], $lang) as $key => $value) {
```

but the method takes two:

```php
protected function getDotted($key, $lang)
```

So `$lang` receives `[]`, the third argument is silently discarded, and `__($key, [], [])`
falls through to the default locale. Every locale directory is read as the default locale
while being *tagged* with its own name, so hover and completion show the default
language's string for all other locales.

Before, for `laravel-filemanager::lfm.nav-back` — correct source file, wrong value:

```
en     Back    vendor/unisharp/laravel-filemanager/src/lang/en/lfm.php
ar     Back    vendor/unisharp/laravel-filemanager/src/lang/ar/lfm.php
ru     Back    vendor/unisharp/laravel-filemanager/src/lang/ru/lfm.php
zh-CN  Back    vendor/unisharp/laravel-filemanager/src/lang/zh-CN/lfm.php
```

After:

```
en     Back
ar     الخلف
ru     Назад
zh-CN  回上一页
```

Dropping the stray `[]` passes the locale through as intended.

This is not only a display problem: it costs coverage. `fromPhpFile()` keeps an entry only
when `array_key_exists($key, $lines)`, where `$lines` comes from token-parsing the file
actually being read, while `getDotted()` returns the *default* locale's array. Only the
intersection of the two survives, so any key not named identically in both is dropped
entirely. On a Laravel 12 app with 34 locales in play, fixing this took the index from
1903 keys to 3448. That baseline of 1903 already has #70 and #71 applied, since without
them the project indexes almost nothing to begin with; the three are independent, touch
different methods, and do not conflict.
