### PR TITLE
Support typed translation accessors

### DIFF
--- a/app/Lsp/Features/Translations/TranslationDocumentMapper.php
+++ b/app/Lsp/Features/Translations/TranslationDocumentMapper.php
@@ -28,9 +28,9 @@ class TranslationDocumentMapper extends DocumentMapper
     protected function patterns(): array
     {
         return [
-            Pattern::method(method: ['get', 'string', 'array', 'choice'], class: Pattern::contract('Translation\\Translator'), argument: 0),
-            Pattern::method(method: ['has', 'hasForLocale', 'get', 'string', 'array', 'choice'], class: Pattern::facade('Lang'), argument: 0),
-            Pattern::method(method: ['get', 'string', 'array'], class: 'trans', argument: 0),
+            Pattern::method(method: ['get', 'string', 'choice'], class: Pattern::contract('Translation\\Translator'), argument: 0),
+            Pattern::method(method: ['has', 'hasForLocale', 'get', 'string', 'choice'], class: Pattern::facade('Lang'), argument: 0),
+            Pattern::method(method: ['get', 'string'], class: 'trans', argument: 0),
             Pattern::method(method: ['__', 'trans', 'trans_choice', '@lang'], argument: 0),
         ];
     }
@@ -161,10 +161,10 @@ class TranslationDocumentMapper extends DocumentMapper
         $method = $argument->item()['methodName'] ?? null;
         $class = $argument->item()['className'] ?? '';
         $indexes = [
-            Pattern::contract('Translation\\Translator') => ['get' => 2, 'string' => 2, 'array' => 2, 'choice' => 3],
-            'Lang'                                       => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'array' => 2, 'choice' => 3],
-            Pattern::support('Facades\\Lang')            => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'array' => 2, 'choice' => 3],
-            'trans'                                      => ['get' => 2, 'string' => 2, 'array' => 2],
+            Pattern::contract('Translation\\Translator') => ['get' => 2, 'string' => 2, 'choice' => 3],
+            'Lang'                                       => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'choice' => 3],
+            Pattern::support('Facades\\Lang')            => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'choice' => 3],
+            'trans'                                      => ['get' => 2, 'string' => 2],
             ''                                           => ['__' => 2, 'trans' => 2, '@lang' => 2, 'trans_choice' => 3],
         ];
 

--- a/app/Lsp/Features/Translations/TranslationDocumentMapper.php
+++ b/app/Lsp/Features/Translations/TranslationDocumentMapper.php
@@ -28,8 +28,9 @@ class TranslationDocumentMapper extends DocumentMapper
     protected function patterns(): array
     {
         return [
-            Pattern::method(method: ['get', 'choice'], class: Pattern::contract('Translation\\Translator'), argument: 0),
-            Pattern::method(method: ['has', 'hasForLocale', 'get', 'choice'], class: Pattern::facade('Lang'), argument: 0),
+            Pattern::method(method: ['get', 'string', 'array', 'choice'], class: Pattern::contract('Translation\\Translator'), argument: 0),
+            Pattern::method(method: ['has', 'hasForLocale', 'get', 'string', 'array', 'choice'], class: Pattern::facade('Lang'), argument: 0),
+            Pattern::method(method: ['get', 'string', 'array'], class: 'trans', argument: 0),
             Pattern::method(method: ['__', 'trans', 'trans_choice', '@lang'], argument: 0),
         ];
     }
@@ -160,9 +161,10 @@ class TranslationDocumentMapper extends DocumentMapper
         $method = $argument->item()['methodName'] ?? null;
         $class = $argument->item()['className'] ?? '';
         $indexes = [
-            Pattern::contract('Translation\\Translator') => ['get' => 2, 'choice' => 3],
-            'Lang'                                       => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'choice' => 3],
-            Pattern::support('Facades\\Lang')            => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'choice' => 3],
+            Pattern::contract('Translation\\Translator') => ['get' => 2, 'string' => 2, 'array' => 2, 'choice' => 3],
+            'Lang'                                       => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'array' => 2, 'choice' => 3],
+            Pattern::support('Facades\\Lang')            => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'array' => 2, 'choice' => 3],
+            'trans'                                      => ['get' => 2, 'string' => 2, 'array' => 2],
             ''                                           => ['__' => 2, 'trans' => 2, '@lang' => 2, 'trans_choice' => 3],
         ];
 

--- a/app/Lsp/Features/Translations/TranslationLocaleCompletionProvider.php
+++ b/app/Lsp/Features/Translations/TranslationLocaleCompletionProvider.php
@@ -50,8 +50,9 @@ class TranslationLocaleCompletionProvider implements CompletionProvider
     protected function patterns(): array
     {
         return [
-            Pattern::method(method: ['get', 'choice'], class: Pattern::contract('Translation\\Translator'), argument: [0, 1, 2, 3]),
-            Pattern::method(method: ['has', 'hasForLocale', 'get', 'choice'], class: Pattern::facade('Lang'), argument: [0, 1, 2, 3]),
+            Pattern::method(method: ['get', 'string', 'choice'], class: Pattern::contract('Translation\\Translator'), argument: [0, 1, 2, 3]),
+            Pattern::method(method: ['has', 'hasForLocale', 'get', 'string', 'choice'], class: Pattern::facade('Lang'), argument: [0, 1, 2, 3]),
+            Pattern::method(method: ['get', 'string'], class: 'trans', argument: [0, 1, 2, 3]),
             Pattern::method(method: ['__', 'trans', 'trans_choice', '@lang'], argument: [0, 1, 2, 3]),
         ];
     }
@@ -68,9 +69,10 @@ class TranslationLocaleCompletionProvider implements CompletionProvider
         $method = $argument->item()['methodName'] ?? null;
         $class = $argument->item()['className'] ?? '';
         $indexes = [
-            Pattern::contract('Translation\\Translator') => ['get' => 2, 'choice' => 3],
-            'Lang'                                       => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'choice' => 3],
-            Pattern::support('Facades\\Lang')            => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'choice' => 3],
+            Pattern::contract('Translation\\Translator') => ['get' => 2, 'string' => 2, 'choice' => 3],
+            'Lang'                                       => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'choice' => 3],
+            Pattern::support('Facades\\Lang')            => ['has' => 1, 'hasForLocale' => 1, 'get' => 2, 'string' => 2, 'choice' => 3],
+            'trans'                                      => ['get' => 2, 'string' => 2],
             ''                                           => ['__' => 2, 'trans' => 2, '@lang' => 2, 'trans_choice' => 3],
         ];
 

--- a/app/Lsp/Features/Translations/TranslationParameterCompletionProvider.php
+++ b/app/Lsp/Features/Translations/TranslationParameterCompletionProvider.php
@@ -50,12 +50,13 @@ class TranslationParameterCompletionProvider implements CompletionProvider
     protected function patterns(): array
     {
         return [
-            Pattern::method(method: 'get', class: Pattern::contract('Translation\\Translator'), argument: 1),
+            Pattern::method(method: ['get', 'string'], class: Pattern::contract('Translation\\Translator'), argument: 1),
             Pattern::method(method: 'choice', class: Pattern::contract('Translation\\Translator'), argument: 2),
             Pattern::method(method: ['__', 'trans', '@lang'], argument: 1),
             Pattern::method(method: 'trans_choice', argument: 2),
-            Pattern::method(method: 'get', class: Pattern::facade('Lang'), argument: 1),
+            Pattern::method(method: ['get', 'string'], class: Pattern::facade('Lang'), argument: 1),
             Pattern::method(method: 'choice', class: Pattern::facade('Lang'), argument: 2),
+            Pattern::method(method: ['get', 'string'], class: 'trans', argument: 1),
         ];
     }
 


### PR DESCRIPTION
## Summary

- Support Laravel's typed `string()` translation accessor.
- Support `string()` on the `Lang` facade and `trans()` translator chain.
- Add locale completion for `string()` calls.
- Add replacement-parameter completion for `string()` calls.
- Preserve locale argument detection for the new method.
- Do not support `array()` until the translation index can distinguish array-valued parent keys from scalar leaf keys.

## Validation

- `php -l app/Lsp/Features/Translations/TranslationLocaleCompletionProvider.php`
- `php -l app/Lsp/Features/Translations/TranslationParameterCompletionProvider.php`
- `vendor/bin/pint --test app/Lsp/Features/Translations/TranslationLocaleCompletionProvider.php app/Lsp/Features/Translations/TranslationParameterCompletionProvider.php`
