### PR TITLE
Fix LSP exits with code 0 ~7s after initialize on Windows

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -103,8 +103,8 @@ jobs:
 
       - name: Download PHP
         run: |
-          curl -L -O https://dl.static-php.dev/static-php-cli/windows/spc-max/php-8.3.9-micro-win.zip
-          tar -xf php-8.3.9-micro-win.zip
+          curl -L -O https://dl.static-php.dev/static-php-cli/windows/spc-max/php-8.3.30-micro-win.zip
+          tar -xf php-8.3.30-micro-win.zip
           mkdir -p buildroot/bin
           mv micro.sfx buildroot/bin
 


### PR DESCRIPTION
Fixes https://github.com/laravel/lsp/issues/64 https://github.com/laravel/lsp/issues/73 potentially https://github.com/laravel/lsp/issues/58

`php-8.3.9-micro-win` appears to have a bug on Windows that causes the LSP process to terminate:

```
[Info  - 5:56:11 PM] Connection to server got closed. Server will restart.
true
[Error - 5:56:11 PM] Server process exited with code 0.
```

After replacing it with `php-8.3.30-micro-win` and rebuilding the binary, the issue no longer occurs on my end.