### PR TITLE
Run project scripts through Symfony Process and a script file

### DIFF
--- a/app/Lsp/PhpCommandDetector.php
+++ b/app/Lsp/PhpCommandDetector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Lsp;
 
 use App\Lsp\Contracts\ExceptionHandler;
+use Symfony\Component\Process\Process;
 use Throwable;
 
 class PhpCommandDetector
@@ -147,21 +148,11 @@ class PhpCommandDetector
     protected function run(array $command): ?string
     {
         try {
-            $process = @proc_open($command, [
-                1 => ['pipe', 'w'],
-                2 => ['pipe', 'w'],
-            ], $pipes, $this->path);
+            $process = new Process($command, $this->path, timeout: null);
 
-            if (!is_resource($process)) {
-                return null;
-            }
+            $process->run();
 
-            $output = stream_get_contents($pipes[1]);
-
-            fclose($pipes[1]);
-            fclose($pipes[2]);
-
-            return proc_close($process) === 0 && $output !== false ? $output : null;
+            return $process->isSuccessful() ? $process->getOutput() : null;
         } catch (Throwable $e) {
             $this->exceptions->report($e);
 

--- a/app/Lsp/ScriptRunner.php
+++ b/app/Lsp/ScriptRunner.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Lsp;
 
+use Symfony\Component\Process\Process;
+use Throwable;
+
 class ScriptRunner
 {
     /**
@@ -36,45 +39,65 @@ class ScriptRunner
      */
     public function run(string $code): ?string
     {
-        $command = [
-            ...$this->command,
-            '-d',
-            'error_reporting=E_ALL & ~(' . self::SUPPRESSED_ERROR_TYPES . ')',
-            'artisan',
-            'tinker',
-            '--execute',
-            $this->code($code),
-        ];
+        $script = $this->write($code);
 
-        $process = proc_open($command, [
-            1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
-        ], $pipes, $this->path);
-
-        if (!is_resource($process)) {
-            return null;
-        }
-
-        $output = stream_get_contents($pipes[1]);
-        $error = stream_get_contents($pipes[2]);
-
-        fclose($pipes[1]);
-        fclose($pipes[2]);
-
-        $exitCode = proc_close($process);
-
-        if ($exitCode !== 0) {
+        if ($script === null) {
             info('PHP runner error.', [
-                'command'  => $command,
-                'stdout'   => $output,
-                'stderr'   => $error,
-                'exitCode' => $exitCode,
+                'message' => 'Unable to write the project script.',
+                'path'    => $this->path,
             ]);
 
             return null;
         }
 
-        return $output !== false ? $output : null;
+        try {
+            $process = new Process([
+                ...$this->command,
+                '-d',
+                'error_reporting=E_ALL & ~(' . self::SUPPRESSED_ERROR_TYPES . ')',
+                'artisan',
+                'tinker',
+                '--execute',
+                'require ' . var_export($script, true) . ';',
+            ], $this->path, timeout: null);
+
+            $process->run();
+
+            if (!$process->isSuccessful()) {
+                info('PHP runner error.', [
+                    'command'  => $process->getCommandLine(),
+                    'stdout'   => $process->getOutput(),
+                    'stderr'   => $process->getErrorOutput(),
+                    'exitCode' => $process->getExitCode(),
+                ]);
+
+                return null;
+            }
+
+            return $process->getOutput();
+        } catch (Throwable $e) {
+            report($e);
+
+            return null;
+        } finally {
+            @unlink($this->path . '/' . $script);
+        }
+    }
+
+    /**
+     * Write the script to a file inside the project.
+     */
+    protected function write(string $code): ?string
+    {
+        $script = 'storage/framework/lsp-' . bin2hex(random_bytes(8)) . '.php';
+        $path = $this->path . '/' . $script;
+        $directory = dirname($path);
+
+        if (!is_dir($directory) && !@mkdir($directory, 0777, true)) {
+            return null;
+        }
+
+        return @file_put_contents($path, $this->code($code)) === false ? null : $script;
     }
 
     /**
@@ -83,6 +106,7 @@ class ScriptRunner
     protected function code(string $code): string
     {
         return implode(PHP_EOL, [
+            '<?php',
             'error_reporting(error_reporting() & ~(' . self::SUPPRESSED_ERROR_TYPES . '));',
             $this->normalize(file_get_contents(__DIR__ . '/Data/Templates/global.php') ?: ''),
             $this->normalize($code),


### PR DESCRIPTION
two things bite windows here.

**bare names dont resolve.** `proc_open()` with an array skips the shell, so theres no PATHEXT lookup and CreateProcess only tries `.exe`. herd exposes php as `.bat` only, so `auto` detection fails and falls back to `["php"]`, which fails the same way (#76). @sameedkun has a clean toggle for it in #73, auto breaks, explicit php.exe works.

**the inline script is too long.** we passed each template as a single argument and five are over the [8191 char](https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation) cmd.exe limit once `global.php` is prepended: blade-components 12265, translations 12040, models 11369, views 10912, tests 8480. thats @zigi05's "command line is too long" in #73. it already bites herd today since php.bat goes through cmd anyway, and moving to `Process` on its own would spread it to every windows user, since it always wraps in `cmd.exe /C`.

so the script now goes to a file and tinker just `require`s it. that takes the command line from 12274 chars down to 53.

few notes:

- the file is project relative on purpose, `sys_get_temp_dir()` would break sail/lando/ddev where php runs in a container
- `timeout: null` keeps the current no-timeout behaviour, happy to add a real one separately
- no composer change, the repo already pulls `symfony/finder` in the same way

i cant test this on windows myself, @JulianGlueck offered to.
