### PR TITLE
Fix proc_open cannot run .bat wrappers on Windows

### DIFF
--- a/app/Lsp/PhpCommandDetector.php
+++ b/app/Lsp/PhpCommandDetector.php
@@ -62,7 +62,7 @@ class PhpCommandDetector
      */
     protected function herd(): array
     {
-        $output = $this->run(['herd', 'which-php']);
+        $output = $this->run('herd which-php');
 
         if ($output === null || str_contains($output, 'No usable PHP version found')) {
             return ['php'];
@@ -142,9 +142,9 @@ class PhpCommandDetector
     /**
      * Run a command in the workspace path.
      *
-     * @param  string[]  $command
+     * @param  string|string[]  $command
      */
-    protected function run(array $command): ?string
+    protected function run(string|array $command): ?string
     {
         try {
             $process = @proc_open($command, [


### PR DESCRIPTION
Fixes https://github.com/laravel/lsp/issues/76

Alternative solution to https://github.com/laravel/lsp/pull/77. Unfortunately, I can't check how `proc_open` behaves with `herd which-php` passed as a string command on macOS.