### PR TITLE
Cache compiled file watcher pattern expressions

### DIFF
--- a/app/Lsp/Support/Pattern.php
+++ b/app/Lsp/Support/Pattern.php
@@ -9,11 +9,26 @@ use Symfony\Component\Finder\Glob;
 class Pattern
 {
     /**
+     * The compiled expressions, keyed by file watcher pattern.
+     *
+     * @var array<string, string>
+     */
+    protected static array $expressions = [];
+
+    /**
      * Determine if the given path matches a file watcher pattern.
      */
     public static function matches(string $path, string $pattern): bool
     {
-        return preg_match(Glob::toRegex(self::normalize($pattern)), self::normalize($path)) === 1;
+        return preg_match(self::expression($pattern), self::normalize($path)) === 1;
+    }
+
+    /**
+     * Get the compiled expression for the given file watcher pattern.
+     */
+    protected static function expression(string $pattern): string
+    {
+        return self::$expressions[$pattern] ??= Glob::toRegex(self::normalize($pattern));
     }
 
     /**

--- a/tests/Unit/PatternTest.php
+++ b/tests/Unit/PatternTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Lsp\Support\Pattern;
+
+test('matches paths against watcher patterns', function () {
+    expect(Pattern::matches('routes/web.php', '**/[Rr]oute{,s}{.php,/*.php,/**/*.php}'))->toBeTrue();
+    expect(Pattern::matches('app/Models/User.php', 'app/{,*,**/*}.php'))->toBeTrue();
+    expect(Pattern::matches('resources/views/welcome.blade.php', '**/{resources,Modules/*/resources}/views/**/*.blade.php'))->toBeTrue();
+    expect(Pattern::matches('app/Models/User.php', 'lang/{*,**/*}'))->toBeFalse();
+});
+
+test('matches windows paths with backslashes', function () {
+    expect(Pattern::matches('app\\Models\\User.php', 'app/{,*,**/*}.php'))->toBeTrue();
+});
+
+test('compiled patterns are not shared between different patterns', function () {
+    expect(Pattern::matches('config/app.php', 'config/{,*,**/*}.php'))->toBeTrue();
+    expect(Pattern::matches('config/app.php', 'tests/**/*'))->toBeFalse();
+    expect(Pattern::matches('config/app.php', 'config/{,*,**/*}.php'))->toBeTrue();
+});
+
+test('matches any pattern and any path', function () {
+    expect(Pattern::matchesAny('config/app.php', ['lang/{*,**/*}', 'config/{,*,**/*}.php']))->toBeTrue();
+    expect(Pattern::matchesAny('config/app.php', ['lang/{*,**/*}', 'tests/**/*']))->toBeFalse();
+
+    expect(Pattern::matchesAnyPath(['README.md', 'config/app.php'], ['config/{,*,**/*}.php']))->toBeTrue();
+    expect(Pattern::matchesAnyPath(['README.md', 'src/main.rs'], ['config/{,*,**/*}.php']))->toBeFalse();
+});


### PR DESCRIPTION
`Pattern::matches()` recompiles the glob on every call, and `ProjectIndex::invalidate()` calls it for each of the 18 providers against each changed path. providers whose patterns dont match cant short circuit, so they recompile every glob for every path.

timing `ProjectIndex::invalidate()` itself, warmed up, median of 15 runs, with a mix of controller/view/test/config paths:

| changed files | before | after |
|---|---|---|
| 20 | 4.0 ms | 0.24 ms |
| 100 | 17.7 ms | 0.77 ms |
| 300 | 52.3 ms | 2.09 ms |

that runs on the notification path, so a branch switch or a build touching a few hundred watched files pays it on every `workspace/didChangeWatchedFiles`.

the expressions are keyed by pattern and the provider list is hardcoded, so the cache is bounded at the 26 patterns they declare.

output is unchanged across every pattern/path pair i tried. the test covers the cache key specifically, keying it wrong makes all four fail.
