### PR TITLE
Skip building the debug snippet when debugging is off

### DIFF
--- a/app/Parser/Parse.php
+++ b/app/Parser/Parse.php
@@ -23,7 +23,9 @@ class Parse
             self::debugBreak();
         }
 
-        self::debug($depth, $node::class, "\e[2m" . self::getCodeSnippet($node) . "\e[0m");
+        if (self::$debug) {
+            self::debug($depth, $node::class, "\e[2m" . self::getCodeSnippet($node) . "\e[0m");
+        }
 
         $class = basename(str_replace('\\', '/', $node::class));
         $parserClass = 'App\\Parsers\\' . $class . 'Parser';


### PR DESCRIPTION
`Parse::parse()` builds a debug snippet for every node it walks:

```php
self::debug($depth, $node::class, "\e[2m" . self::getCodeSnippet($node) . "\e[0m");
```

php evaluates the argument before `debug()` gets to check `self::$debug`, so `getCodeSnippet()` runs on every node no matter what. it does a `getText()`, a `str_replace` and a `preg_replace` over that text, then keeps 50 chars. `$debug` is false unless you pass it to the walker yourself, so in a running server all of it is thrown away.

parsing 162 files from a real app, best of 5 each:

| | total | mean |
|---|---|---|
| before | 636.5 ms | 3.93 ms |
| after | 557.7 ms | 3.44 ms |

worst files: QuickSetup.php 38.0 -> 32.4 ms, VendingMachineController.php 23.3 -> 20.5, sidebar.blade.php 20.1 -> 18.5, web.php 19.5 -> 17.4.

`Document` is rebuilt on every `didChange`, so this runs per keystroke.

`detect()` output is unchanged, i hashed it across 135 files before and after and got the same digest. debug output with `$debug = true` is unchanged too.
