### PR TITLE
Bootstrap the application directly instead of running project scripts through Tinker

### DIFF
--- a/app/Lsp/ScriptRunner.php
+++ b/app/Lsp/ScriptRunner.php
@@ -119,10 +119,12 @@ class ScriptRunner
             return [];
         }
 
+        $path = realpath($this->path) ?: $this->path;
+
         return [
             "define('LARAVEL_START', microtime(true));",
-            "require __DIR__ . '/../../vendor/autoload.php';",
-            "\$app = require __DIR__ . '/../../bootstrap/app.php';",
+            'require ' . var_export($path . '/vendor/autoload.php', true) . ';',
+            '$app = require ' . var_export($path . '/bootstrap/app.php', true) . ';',
             '$app->make(Illuminate\\Contracts\\Console\\Kernel::class)->bootstrap();',
         ];
     }

--- a/app/Lsp/ScriptRunner.php
+++ b/app/Lsp/ScriptRunner.php
@@ -15,6 +15,11 @@ class ScriptRunner
     protected const SUPPRESSED_ERROR_TYPES = 'E_WARNING | E_CORE_WARNING | E_COMPILE_WARNING | E_USER_WARNING | E_DEPRECATED | E_USER_DEPRECATED';
 
     /**
+     * Whether the project can be bootstrapped without artisan.
+     */
+    protected ?bool $bootable = null;
+
+    /**
      * Create a new PHP runner instance.
      *
      * @param  array<int, string>  $command
@@ -51,15 +56,7 @@ class ScriptRunner
         }
 
         try {
-            $process = new Process([
-                ...$this->command,
-                '-d',
-                'error_reporting=E_ALL & ~(' . self::SUPPRESSED_ERROR_TYPES . ')',
-                'artisan',
-                'tinker',
-                '--execute',
-                'require ' . var_export($script, true) . ';',
-            ], $this->path, timeout: null);
+            $process = new Process($this->arguments($script), $this->path, timeout: null);
 
             $process->run();
 
@@ -85,6 +82,52 @@ class ScriptRunner
     }
 
     /**
+     * Get the process arguments used to run the given script.
+     *
+     * @return array<int, string>
+     */
+    protected function arguments(string $script): array
+    {
+        $arguments = [
+            ...$this->command,
+            '-d',
+            'error_reporting=E_ALL & ~(' . self::SUPPRESSED_ERROR_TYPES . ')',
+        ];
+
+        return $this->bootable()
+            ? [...$arguments, $script]
+            : [...$arguments, 'artisan', 'tinker', '--execute', 'require ' . var_export($script, true) . ';'];
+    }
+
+    /**
+     * Determine if the project can be bootstrapped without artisan.
+     */
+    protected function bootable(): bool
+    {
+        return $this->bootable ??= is_file($this->path . '/vendor/autoload.php')
+            && is_file($this->path . '/bootstrap/app.php');
+    }
+
+    /**
+     * Get the lines that bootstrap the application inside the script.
+     *
+     * @return array<int, string>
+     */
+    protected function bootstrap(): array
+    {
+        if (!$this->bootable()) {
+            return [];
+        }
+
+        return [
+            "define('LARAVEL_START', microtime(true));",
+            "require __DIR__ . '/../../vendor/autoload.php';",
+            "\$app = require __DIR__ . '/../../bootstrap/app.php';",
+            '$app->make(Illuminate\\Contracts\\Console\\Kernel::class)->bootstrap();',
+        ];
+    }
+
+    /**
      * Write the script to a file inside the project.
      */
     protected function write(string $code): ?string
@@ -107,6 +150,7 @@ class ScriptRunner
     {
         return implode(PHP_EOL, [
             '<?php',
+            ...$this->bootstrap(),
             'error_reporting(error_reporting() & ~(' . self::SUPPRESSED_ERROR_TYPES . '));',
             $this->normalize(file_get_contents(__DIR__ . '/Data/Templates/global.php') ?: ''),
             $this->normalize($code),

--- a/app/Lsp/ScriptRunner.php
+++ b/app/Lsp/ScriptRunner.php
@@ -119,12 +119,10 @@ class ScriptRunner
             return [];
         }
 
-        $path = realpath($this->path) ?: $this->path;
-
         return [
             "define('LARAVEL_START', microtime(true));",
-            'require ' . var_export($path . '/vendor/autoload.php', true) . ';',
-            '$app = require ' . var_export($path . '/bootstrap/app.php', true) . ';',
+            "require getcwd() . '/vendor/autoload.php';",
+            "\$app = require getcwd() . '/bootstrap/app.php';",
             '$app->make(Illuminate\\Contracts\\Console\\Kernel::class)->bootstrap();',
         ];
     }

--- a/tests/Unit/ScriptRunnerTest.php
+++ b/tests/Unit/ScriptRunnerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Lsp\ScriptRunner;
+
+function scriptRunnerProject(string $suffix): string
+{
+    $root = sys_get_temp_dir() . '/lsp-runner-' . getmypid() . '-' . $suffix;
+
+    @mkdir($root . '/vendor', 0777, true);
+    @mkdir($root . '/bootstrap', 0777, true);
+    touch($root . '/vendor/autoload.php');
+    touch($root . '/bootstrap/app.php');
+
+    return $root;
+}
+
+function scriptRunnerFor(string $root): ScriptRunner
+{
+    return new class($root, ['php']) extends ScriptRunner
+    {
+        public function generate(string $code): string
+        {
+            return $this->code($code);
+        }
+    };
+}
+
+function scriptRunnerCleanup(string ...$paths): void
+{
+    foreach ($paths as $path) {
+        if (is_link($path)) {
+            @unlink($path);
+
+            continue;
+        }
+
+        if (!is_dir($path)) {
+            @unlink($path);
+
+            continue;
+        }
+
+        foreach (scandir($path) ?: [] as $entry) {
+            if ($entry !== '.' && $entry !== '..') {
+                scriptRunnerCleanup($path . '/' . $entry);
+            }
+        }
+
+        @rmdir($path);
+    }
+}
+
+test('the bootstrap targets the project root even when storage is a symlink', function () {
+    $root = scriptRunnerProject('symlinked-storage');
+    $shared = sys_get_temp_dir() . '/lsp-shared-' . getmypid();
+
+    @mkdir($shared . '/framework', 0777, true);
+
+    if (!@symlink($shared, $root . '/storage')) {
+        scriptRunnerCleanup($root, $shared);
+
+        $this->markTestSkipped('Unable to create a symlink on this platform.');
+    }
+
+    try {
+        $base = realpath($root);
+
+        expect(scriptRunnerFor($root)->generate('<?php //'))
+            ->toContain("require '" . $base . "/vendor/autoload.php';")
+            ->toContain("require '" . $base . "/bootstrap/app.php';");
+    } finally {
+        scriptRunnerCleanup($root, $shared);
+    }
+});
+
+test('the bootstrap escapes a project path containing a quote', function () {
+    $root = scriptRunnerProject("it's");
+
+    try {
+        $generated = scriptRunnerFor($root)->generate('<?php //');
+
+        expect($generated)->toContain(var_export(realpath($root) . '/vendor/autoload.php', true));
+
+        $script = sys_get_temp_dir() . '/lsp-lint-' . getmypid() . '.php';
+        file_put_contents($script, $generated);
+        exec('php -l ' . escapeshellarg($script) . ' 2>&1', $output, $status);
+        @unlink($script);
+
+        expect($status)->toBe(0);
+    } finally {
+        scriptRunnerCleanup($root);
+    }
+});
+
+test('the bootstrap is empty when the project cannot be booted without artisan', function () {
+    $root = sys_get_temp_dir() . '/lsp-runner-' . getmypid() . '-bare';
+
+    @mkdir($root, 0777, true);
+
+    try {
+        expect(scriptRunnerFor($root)->generate('<?php //'))
+            ->not->toContain('LARAVEL_START');
+    } finally {
+        scriptRunnerCleanup($root);
+    }
+});

--- a/tests/Unit/ScriptRunnerTest.php
+++ b/tests/Unit/ScriptRunnerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Lsp\ScriptRunner;
+use Symfony\Component\Process\Process;
 
 function scriptRunnerProject(string $suffix): string
 {
@@ -8,8 +9,24 @@ function scriptRunnerProject(string $suffix): string
 
     @mkdir($root . '/vendor', 0777, true);
     @mkdir($root . '/bootstrap', 0777, true);
-    touch($root . '/vendor/autoload.php');
-    touch($root . '/bootstrap/app.php');
+    file_put_contents($root . '/vendor/autoload.php', '<?php define("SCRIPT_RUNNER_PROJECT", dirname(__DIR__));');
+    file_put_contents($root . '/bootstrap/app.php', <<<'PHP'
+    <?php
+
+    return new class
+    {
+        public function make(string $abstract): object
+        {
+            return new class
+            {
+                public function bootstrap(): void
+                {
+                    define('SCRIPT_RUNNER_BOOTED', true);
+                }
+            };
+        }
+    };
+    PHP);
 
     return $root;
 }
@@ -63,32 +80,42 @@ test('the bootstrap targets the project root even when storage is a symlink', fu
     }
 
     try {
-        $base = realpath($root);
-
-        expect(scriptRunnerFor($root)->generate('<?php //'))
-            ->toContain("require '" . $base . "/vendor/autoload.php';")
-            ->toContain("require '" . $base . "/bootstrap/app.php';");
+        expect(scriptRunnerFor($root)->json('echo json_encode([SCRIPT_RUNNER_PROJECT, SCRIPT_RUNNER_BOOTED]);'))
+            ->toBe([realpath($root), true]);
     } finally {
         scriptRunnerCleanup($root, $shared);
     }
 });
 
-test('the bootstrap escapes a project path containing a quote', function () {
+test('the bootstrap supports a project path containing a quote', function () {
     $root = scriptRunnerProject("it's");
 
     try {
-        $generated = scriptRunnerFor($root)->generate('<?php //');
-
-        expect($generated)->toContain(var_export(realpath($root) . '/vendor/autoload.php', true));
-
-        $script = sys_get_temp_dir() . '/lsp-lint-' . getmypid() . '.php';
-        file_put_contents($script, $generated);
-        exec('php -l ' . escapeshellarg($script) . ' 2>&1', $output, $status);
-        @unlink($script);
-
-        expect($status)->toBe(0);
+        expect(scriptRunnerFor($root)->json('echo json_encode([SCRIPT_RUNNER_PROJECT, SCRIPT_RUNNER_BOOTED]);'))
+            ->toBe([realpath($root), true]);
     } finally {
         scriptRunnerCleanup($root);
+    }
+});
+
+test('the bootstrap resolves the project inside the PHP environment', function () {
+    $host = scriptRunnerProject('host');
+    $runtime = scriptRunnerProject('runtime');
+
+    try {
+        mkdir($runtime . '/storage/framework', 0777, true);
+
+        $script = 'storage/framework/lsp.php';
+        file_put_contents($runtime . '/' . $script, scriptRunnerFor($host)->generate(
+            'echo json_encode([SCRIPT_RUNNER_PROJECT, SCRIPT_RUNNER_BOOTED]);'
+        ));
+
+        $process = new Process([PHP_BINARY, $script], $runtime);
+        $process->mustRun();
+
+        expect(json_decode($process->getOutput(), true))->toBe([realpath($runtime), true]);
+    } finally {
+        scriptRunnerCleanup($host, $runtime);
     }
 });
 


### PR DESCRIPTION
we boot psysh 17 times at startup to run scripts that never touch it. the script now bootstraps the app itself and php runs it directly.

cold index, real laravel 12 app, 17 providers, two passes:

| | before | after |
|---|---|---|
| | 5.33 s | 3.83 s |
| | 5.01 s | 3.90 s |

ran all 15 templates against four apps, laravel 10 through 13. identical on 10, 11 and 12. on the 13 app six differ and the new output is the correct one: tinker there turns `...` into `..` on stdout, so `array(...)` from `global.php` came back as `array(..)`. even `echo "A...B"` gives `A..B`. couldnt pin which package does it, three other tinker v3 apps are clean.

falls back to `artisan tinker` if `vendor/autoload.php` or `bootstrap/app.php` arent where expected, and defines `LARAVEL_START` like artisan does.
