### PR TITLE
Add a basePath option for monorepo projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Editor clients pass configuration through the LSP `initializationOptions` object
 
 | Option                  | Type       | Default                                 | Description                                                                                              |
 | ----------------------- | ---------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `basePath`              | `string`   | `""`                                    | Set where the Laravel application sits relative to the workspace root, for a project kept in a subdirectory. |
 | `phpEnvironment`        | `string`   | `"auto"`                                | Select the environment used to detect the PHP command for indexing project data.                         |
 | `phpCommand`            | `string[]` | Detected from `phpEnvironment`          | Use an explicit command and arguments, such as `["php"]` or `["./vendor/bin/sail", "php"]`.              |
 | `definitionProvider`    | `boolean`  | `true`                                  | Advertise definition support to the editor. Definitions are resolved from enabled document link options. |

--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -37,7 +37,10 @@ final class Initialize implements Method
             return JsonRpcResponse::error($request->id(), -32602, 'Initialize request must include a workspace root URI.');
         }
 
-        $uri = FileUri::of($rootUri);
+        $uri = self::projectUri(
+            FileUri::of($rootUri),
+            (string) $request->string('initializationOptions.basePath', ''),
+        );
 
         if (!file_exists($uri->path('artisan'))) {
             return JsonRpcResponse::error($request->id(), -32602, 'Initialize request root URI must be a Laravel project.');
@@ -90,6 +93,20 @@ final class Initialize implements Method
                 'phpCommand'     => $project->scripts->command(),
             ],
         ]);
+    }
+
+    /**
+     * Resolve the URI of the Laravel project inside the workspace.
+     *
+     * A workspace does not always have the application at its root. It may
+     * sit in a subdirectory beside a frontend or another service, so the
+     * base path says where to look for it, relative to the workspace root.
+     */
+    public static function projectUri(FileUri $uri, string $basePath): FileUri
+    {
+        $basePath = trim(str_replace('\\', '/', trim($basePath)), '/');
+
+        return $basePath === '' || $basePath === '.' ? $uri : $uri->joinPaths($basePath);
     }
 
     /**

--- a/tests/Unit/ProjectUriTest.php
+++ b/tests/Unit/ProjectUriTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Lsp\Methods\Initialize;
+use App\Lsp\Support\FileUri;
+
+function projectPathFor(string $basePath): string
+{
+    return Initialize::projectUri(FileUri::fromPath('/workspace'), $basePath)->path();
+}
+
+it('uses the workspace root when no base path is configured', function () {
+    expect(projectPathFor(''))->toBe('/workspace')
+        ->and(projectPathFor('   '))->toBe('/workspace')
+        ->and(projectPathFor('.'))->toBe('/workspace');
+});
+
+it('resolves the project against the workspace root', function () {
+    expect(projectPathFor('api'))->toBe('/workspace/api')
+        ->and(projectPathFor('apps/api'))->toBe('/workspace/apps/api');
+});
+
+it('ignores separators around the base path', function () {
+    expect(projectPathFor('/api/'))->toBe('/workspace/api')
+        ->and(projectPathFor(' api '))->toBe('/workspace/api')
+        ->and(projectPathFor('apps\\api'))->toBe('/workspace/apps/api');
+});
+
+it('keeps the base path inside the workspace', function () {
+    // The base path names a directory in the workspace, so an absolute one is
+    // read as relative rather than pointing the server somewhere else.
+    expect(projectPathFor('/etc'))->toBe('/workspace/etc');
+});


### PR DESCRIPTION
The project root is always the workspace root, so a repository that keeps the application beside a frontend or another service never initializes. The server refuses it for having no `artisan` file, and there is no way for the editor to say where the application actually lives.

This adds a `basePath` option, resolved against the workspace root before the `artisan` check.

```json
"initializationOptions": { "basePath": "api" }
```

### Why the server
The VS Code extension already solves this on the client, in `getProjectWorkspaceFolder()` (laravel/vs-code-extension#661): it resolves `Laravel.basePath` and hands the language client a workspace folder pointing at the subdirectory, so the server is launched against the application rather than the repository.

Other editors cannot do that. Zed's extension API has no equivalent hook — `zed::Command` carries only a command, arguments, and environment, `worktree` is read only, and the `rootUri` is derived by the editor rather than the extension. Sublime and the documented Neovim setup are thin clients in the same position.

They all pass `initializationOptions` through, though, so resolving the base path here gives every editor the behavior VS Code already has, without a change in any of them.

### What it resolves

The base path names a directory in the workspace, so it is treated as relative:

| Option | Project root |
| --- | --- |
| unset, `""`, `"."` | the workspace root, as before |
| `"api"` | `<workspace>/api` |
| `"apps/api"` | `<workspace>/apps/api` |
| `"/api/"`, `" api "`, `"apps\api"` | separators and whitespace trimmed |
| `"/etc"` | `<workspace>/etc`, not `/etc` |

Reading an absolute path as relative keeps the server inside the workspace rather than pointing it somewhere else entirely.

### Notes

- Everything downstream reads `Project`, so nothing else needed changing. `RegisterFileWatchers` already sends `baseUri` from the project URI with relative patterns, so watchers scope themselves to the subdirectory, and `ScriptRunner` and path resolution follow the same way.
- This is not multi root support. #66 settled that the server stays scoped to a single project and the client spawns one server per project. This is a single project that happens to sit in a subdirectory, which that decision did not cover.
- The option is named to match the existing ones, and `Laravel.basePath` in the VS Code extension.
- The VS Code extension keeps working unchanged, since it resolves the folder itself and never sends the option. If it later wanted to pass `basePath` through instead, that would be a change on its side rather than here.

### Testing

Four tests covering the resolution: an unset, blank, or `.` base path leaving the root alone; a nested path resolving against it; separators and whitespace being ignored; and an absolute path staying inside the workspace.

Also driven end to end over real JSON-RPC against `php server lsp` with a workspace laid out as `monorepo/{api, web}`, where only `api` is a Laravel application:

- `rootUri` at the repository root with no base path is refused, as before
- the same `rootUri` with `basePath` set to `api` initializes, and the project root resolves to `monorepo/api`
