### PR TITLE
Confine the generated Pest helper file to the project root

### DIFF
--- a/app/Lsp/Support/FileUri.php
+++ b/app/Lsp/Support/FileUri.php
@@ -75,6 +75,18 @@ class FileUri implements JsonSerializable
     }
 
     /**
+     * Determine if the given path resolves to somewhere inside this URI.
+     */
+    public function contains(string $path): bool
+    {
+        $basePath = self::resolve($this->path());
+        $resolved = self::resolve($path);
+
+        return $basePath !== ''
+            && ($resolved === $basePath || str_starts_with($resolved, rtrim($basePath, '/') . '/'));
+    }
+
+    /**
      * Resolve a filesystem path that is not required to exist.
      *
      * The deepest existing ancestor is resolved with realpath() so symlinked

--- a/app/Lsp/Support/FileUri.php
+++ b/app/Lsp/Support/FileUri.php
@@ -52,7 +52,7 @@ class FileUri implements JsonSerializable
 
         return $line === null
             ? $target
-            : new self($target.'#L'.max(1, $line));
+            : new self($target . '#L' . max(1, $line));
     }
 
     /**
@@ -67,11 +67,50 @@ class FileUri implements JsonSerializable
             return '';
         }
 
-        if ($basePath === '' || !str_starts_with($normalized, $basePath.'/')) {
+        if ($basePath === '' || !str_starts_with($normalized, $basePath . '/')) {
             return $path;
         }
 
         return substr($normalized, strlen($basePath) + 1);
+    }
+
+    /**
+     * Resolve a filesystem path that is not required to exist.
+     *
+     * The deepest existing ancestor is resolved with realpath() so symlinked
+     * directories are followed, and the remaining segments are then applied
+     * lexically so "." and ".." never survive into the resolved path.
+     */
+    public static function resolve(string $path): string
+    {
+        $path = self::normalizePath($path);
+        $segments = [];
+
+        while (!file_exists($path)) {
+            $parent = self::normalizePath(dirname($path));
+
+            if ($parent === $path) {
+                break;
+            }
+
+            array_unshift($segments, basename($path));
+
+            $path = $parent;
+        }
+
+        $resolved = rtrim(self::normalizePath(realpath($path) ?: $path), '/');
+
+        foreach ($segments as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+
+            $resolved = $segment === '..'
+                ? rtrim(self::normalizePath(dirname($resolved)), '/')
+                : $resolved . '/' . $segment;
+        }
+
+        return $resolved === '' ? '/' : $resolved;
     }
 
     /**
@@ -95,7 +134,7 @@ class FileUri implements JsonSerializable
      */
     public static function fromPath(string $path): self
     {
-        return new self('file://'.self::encodePath($path));
+        return new self('file://' . self::encodePath($path));
     }
 
     /**
@@ -120,7 +159,7 @@ class FileUri implements JsonSerializable
         $path = str_replace('\\', '/', $path);
 
         if (preg_match('/^[A-Za-z]:(?:\/|$)/', $path) === 1) {
-            return strtoupper($path[0]).substr($path, 1);
+            return strtoupper($path[0]) . substr($path, 1);
         }
 
         return $path;
@@ -132,7 +171,7 @@ class FileUri implements JsonSerializable
     protected static function encodePath(string $path): string
     {
         $path = str_replace('\\', '/', $path);
-        $path = '/'.ltrim($path, '/');
+        $path = '/' . ltrim($path, '/');
 
         return implode('/', array_map('rawurlencode', explode('/', $path)));
     }

--- a/app/Lsp/Watchers/PestHelperWatcher.php
+++ b/app/Lsp/Watchers/PestHelperWatcher.php
@@ -11,6 +11,11 @@ use Throwable;
 class PestHelperWatcher implements FileWatcher
 {
     /**
+     * The workspace-relative path used when no valid path is configured.
+     */
+    protected const DEFAULT_HELPER_FILE_PATH = 'storage/framework/testing/_pest.php';
+
+    /**
      * Create a new Pest helper watcher instance.
      */
     public function __construct(protected Project $project)
@@ -113,10 +118,27 @@ class PestHelperWatcher implements FileWatcher
      */
     protected function helperFilePath(): string
     {
-        $options = $this->project->all();
-        $relativePath = $options['pestHelperFilePath'] ?? 'storage/framework/testing/_pest.php';
+        $configured = $this->project->all()['pestHelperFilePath'] ?? null;
 
-        return $this->project->path(is_string($relativePath) ? $relativePath : 'storage/framework/testing/_pest.php');
+        if (!is_string($configured) || trim($configured) === '') {
+            return $this->defaultHelperFilePath();
+        }
+
+        $path = $this->project->path($configured);
+
+        if (!$this->project->uri()->contains($path)) {
+            return $this->defaultHelperFilePath();
+        }
+
+        return $path;
+    }
+
+    /**
+     * Get the default Pest helper file path.
+     */
+    protected function defaultHelperFilePath(): string
+    {
+        return $this->project->path(self::DEFAULT_HELPER_FILE_PATH);
     }
 
     /**

--- a/app/Lsp/Watchers/PestHelperWatcher.php
+++ b/app/Lsp/Watchers/PestHelperWatcher.php
@@ -6,6 +6,8 @@ namespace App\Lsp\Watchers;
 
 use App\Lsp\Contracts\FileWatcher;
 use App\Lsp\Project;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Throwable;
 
 class PestHelperWatcher implements FileWatcher
@@ -18,8 +20,10 @@ class PestHelperWatcher implements FileWatcher
     /**
      * Create a new Pest helper watcher instance.
      */
-    public function __construct(protected Project $project)
-    {
+    public function __construct(
+        protected Project $project,
+        protected LoggerInterface $logger = new NullLogger,
+    ) {
         //
     }
 
@@ -127,6 +131,11 @@ class PestHelperWatcher implements FileWatcher
         $path = $this->project->path($configured);
 
         if (!$this->project->uri()->contains($path)) {
+            $this->logger->warning('Ignoring a Pest helper file path outside of the project root.', [
+                'pestHelperFilePath' => $configured,
+                'fallback'           => self::DEFAULT_HELPER_FILE_PATH,
+            ]);
+
             return $this->defaultHelperFilePath();
         }
 

--- a/tests/Unit/FileUriTest.php
+++ b/tests/Unit/FileUriTest.php
@@ -48,3 +48,60 @@ test('relative path returns an empty string for the base path itself', function 
 
     expect($uri->relativePath('D:\\a\\project\\project'))->toBe('');
 });
+
+test('contains a path inside the project root', function () {
+    $uri = FileUri::of('file:///home/runner/work/project');
+
+    expect($uri->contains('/home/runner/work/project/storage/framework/testing/_pest.php'))
+        ->toBeTrue();
+});
+
+test('contains the project root itself', function () {
+    $uri = FileUri::of('file:///home/runner/work/project');
+
+    expect($uri->contains('/home/runner/work/project'))->toBeTrue();
+});
+
+test('does not contain a path that traverses out of the project root', function () {
+    $uri = FileUri::of('file:///home/runner/work/project');
+
+    expect($uri->contains('/home/runner/work/project/../../tmp/evil_pest.php'))
+        ->toBeFalse();
+});
+
+test('does not contain a sibling directory sharing the project root prefix', function () {
+    $uri = FileUri::of('file:///home/runner/work/project');
+
+    expect($uri->contains('/home/runner/work/project-two/_pest.php'))->toBeFalse();
+});
+
+test('contains a path that traverses out of and back into the project root', function () {
+    $uri = FileUri::of('file:///home/runner/work/project');
+
+    expect($uri->contains('/home/runner/work/project/tests/../storage/_pest.php'))
+        ->toBeTrue();
+});
+
+test('resolve removes traversal segments from a path that does not exist', function () {
+    $temp = FileUri::resolve(sys_get_temp_dir());
+    $missing = $temp . '/lsp-' . bin2hex(random_bytes(4));
+
+    expect(FileUri::resolve($missing . '/project/../../tmp/evil_pest.php'))
+        ->toBe($temp . '/tmp/evil_pest.php');
+});
+
+test('resolve follows symlinked ancestors', function () {
+    $base = sys_get_temp_dir() . '/lsp-' . bin2hex(random_bytes(4));
+    $target = $base . '/target';
+    $link = $base . '/link';
+
+    mkdir($target, 0777, true);
+    symlink($target, $link);
+
+    expect(FileUri::resolve($link . '/_pest.php'))
+        ->toBe(FileUri::resolve($target) . '/_pest.php');
+
+    unlink($link);
+    rmdir($target);
+    rmdir($base);
+})->skipOnWindows();

--- a/tests/Unit/PestHelperWatcherTest.php
+++ b/tests/Unit/PestHelperWatcherTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Lsp\Project;
+use App\Lsp\ProjectIndex;
+use App\Lsp\ScriptRunner;
+use App\Lsp\Support\FileUri;
+use App\Lsp\Watchers\PestHelperWatcher;
+use Illuminate\Container\Container;
+
+function pestHelperFilePath(array $options): string
+{
+    $uri = FileUri::of('file:///home/runner/work/project');
+
+    $watcher = new class(new Project($uri, $options, new ProjectIndex(new Container), new ScriptRunner($uri->path(), ['php']))) extends PestHelperWatcher
+    {
+        public function path(): string
+        {
+            return $this->helperFilePath();
+        }
+    };
+
+    return $watcher->path();
+}
+
+test('uses the default path when none is configured', function () {
+    expect(pestHelperFilePath([]))
+        ->toBe('/home/runner/work/project/storage/framework/testing/_pest.php');
+});
+
+test('uses a configured path inside the project root', function () {
+    expect(pestHelperFilePath(['pestHelperFilePath' => 'storage/_pest.php']))
+        ->toBe('/home/runner/work/project/storage/_pest.php');
+});
+
+test('falls back to the default path when the configured path escapes the project root', function () {
+    expect(pestHelperFilePath(['pestHelperFilePath' => '../../tmp/evil_pest.php']))
+        ->toBe('/home/runner/work/project/storage/framework/testing/_pest.php');
+});
+
+test('falls back to the default path for a deep traversal chain', function () {
+    expect(pestHelperFilePath(['pestHelperFilePath' => 'storage/../../../../../etc/evil_pest.php']))
+        ->toBe('/home/runner/work/project/storage/framework/testing/_pest.php');
+});
+
+test('falls back to the default path when the configured path is not a string', function () {
+    expect(pestHelperFilePath(['pestHelperFilePath' => ['storage/_pest.php']]))
+        ->toBe('/home/runner/work/project/storage/framework/testing/_pest.php');
+});
+
+test('falls back to the default path when the configured path is blank', function () {
+    expect(pestHelperFilePath(['pestHelperFilePath' => '   ']))
+        ->toBe('/home/runner/work/project/storage/framework/testing/_pest.php');
+});


### PR DESCRIPTION
Fixes #45.

## The problem

`pestHelperFilePath` arrives from the client's `initializationOptions` and is joined straight onto the project root:

```php
$relativePath = $options['pestHelperFilePath'] ?? 'storage/framework/testing/_pest.php';

return $this->project->path(is_string($relativePath) ? $relativePath : '...');
```

That result is the target of `mkdir()` and `file_put_contents()` in `generate()`. Nothing keeps it inside the workspace, so a value like `../../tmp/evil_pest.php` writes the generated Pest helper outside the project root as the LSP process user.

The default (`storage/framework/testing/_pest.php`) is safe. The escape needs a workspace-supplied setting, and since #67 landed `generate()` also runs at startup, not only on a watched-file change.

## The fix

Resolve the configured path and require it to land inside the project root, otherwise fall back to the default.

Two new helpers on `FileUri`:

- `FileUri::resolve()` resolves a path that is **not required to exist**. `relativePath()` already leans on `realpath()`, but the Pest helper is a write target, so the check has to run before the file is there. `resolve()` walks up to the deepest existing ancestor, resolves that with `realpath()` so symlinked directories are followed, then re-applies the remaining segments lexically so no `.` or `..` survives.
- `FileUri::contains()` resolves both sides and checks the target is the base path or sits under `base + '/'`. Comparing with the trailing separator keeps a sibling such as `project-two` from matching a `project` root, the same trap `relativePath()` already guards against.

`PestHelperWatcher` then treats the default as a named constant, rejects non-string and blank values up front, and logs the rejected value at warning level rather than silently swapping the path, so a misconfigured setting is visible in the server log.

Paths that traverse out of the root and back in (`tests/../storage/_pest.php`) still resolve inside the project and are still accepted.

## Tests

`tests/Unit/FileUriTest.php` covers `resolve()` and `contains()`: traversal out of the root, a sibling directory sharing the root prefix, traversal that returns inside the root, and a symlinked ancestor.

`tests/Unit/PestHelperWatcherTest.php` covers the resolved helper path: default when unset, honoured when inside the root, and fallback for traversal, deep traversal chains, non-string values, and blank strings.

Note: the `tests/Unit/ParserTest.php` and `DetectTest.php` failures on this branch are present on `main` too, they read snippets from `tests/../snippets` while the fixtures live at the repo root. Not touched here.
