### PR TITLE
Add Yerd and Lerd PHP environment detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,14 @@ The `phpEnvironment` option controls which PHP command is used when the server r
 
 | Value   | PHP command behavior                                               |
 | ------- | ------------------------------------------------------------------ |
-| `auto`  | Try Herd, Valet, Sail, Lando, DDEV, then local PHP                 |
+| `auto`  | Try Herd, Valet, Sail, Lando, DDEV, Yerd, Lerd, then local PHP     |
 | `herd`  | Use `herd which-php`                                               |
 | `valet` | Use `valet which-php`                                              |
 | `sail`  | Use `./vendor/bin/sail php` when Sail is running                   |
 | `lando` | Use `lando php` when available                                     |
 | `ddev`  | Use `ddev php` when available                                      |
+| `yerd`  | Use `yerd which php`                                               |
+| `lerd`  | Use `lerd php` when available                                      |
 | `local` | Use the local PHP binary resolved from `php -r 'echo PHP_BINARY;'` |
 
 If detection fails, or an unknown value is provided, the server falls back to `php`.

--- a/app/Lsp/PhpCommandDetector.php
+++ b/app/Lsp/PhpCommandDetector.php
@@ -33,6 +33,7 @@ class PhpCommandDetector
             'lando' => $this->lando(),
             'ddev'  => $this->ddev(),
             'yerd'  => $this->yerd(),
+            'lerd'  => $this->lerd(),
             'local' => $this->local(),
             'auto'  => $this->auto(),
             default => ['php'],
@@ -131,6 +132,22 @@ class PhpCommandDetector
     protected function yerd(): array
     {
         return $this->binaryCommand($this->run(['yerd', 'which', 'php']));
+    }
+
+    /**
+     * Resolve the Lerd PHP command.
+     *
+     * Lerd runs PHP inside a rootless Podman container, so the binary path it
+     * reports is meaningless on the host. Its "lerd php" passthrough execs into
+     * the container the working directory's site is served from.
+     *
+     * @return string[]
+     */
+    protected function lerd(): array
+    {
+        return $this->run(['lerd', 'php', '-r', 'echo PHP_BINARY;']) === null
+            ? ['php']
+            : ['lerd', 'php'];
     }
 
     /**

--- a/app/Lsp/PhpCommandDetector.php
+++ b/app/Lsp/PhpCommandDetector.php
@@ -43,11 +43,16 @@ class PhpCommandDetector
     /**
      * Auto-detect the PHP command.
      *
+     * Yerd and Lerd are probed after the existing environments so detection
+     * order does not change for anyone, but before "local": Lerd puts a "php"
+     * shim on the PATH that execs into its container, so the local probe would
+     * otherwise report a container path that does not exist on the host.
+     *
      * @return string[]
      */
     protected function auto(): array
     {
-        foreach (['herd', 'valet', 'sail', 'lando', 'ddev', 'local'] as $environment) {
+        foreach (['herd', 'valet', 'sail', 'lando', 'ddev', 'yerd', 'lerd', 'local'] as $environment) {
             $command = $this->{$environment}();
 
             if ($command !== ['php']) {

--- a/app/Lsp/PhpCommandDetector.php
+++ b/app/Lsp/PhpCommandDetector.php
@@ -32,6 +32,7 @@ class PhpCommandDetector
             'sail'  => $this->sail(),
             'lando' => $this->lando(),
             'ddev'  => $this->ddev(),
+            'yerd'  => $this->yerd(),
             'local' => $this->local(),
             'auto'  => $this->auto(),
             default => ['php'],
@@ -116,6 +117,20 @@ class PhpCommandDetector
         return $this->run(['ddev', 'php', '-r', 'echo PHP_BINARY;']) === null
             ? ['php']
             : ['ddev', 'php'];
+    }
+
+    /**
+     * Resolve the Yerd PHP command.
+     *
+     * Yerd builds native PHP binaries on the host and resolves the version from
+     * the site the working directory belongs to, so "yerd which php" reports the
+     * same binary "yerd exec php" would run.
+     *
+     * @return string[]
+     */
+    protected function yerd(): array
+    {
+        return $this->binaryCommand($this->run(['yerd', 'which', 'php']));
     }
 
     /**

--- a/tests/Unit/PhpCommandDetectorTest.php
+++ b/tests/Unit/PhpCommandDetectorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Lsp\Contracts\ExceptionHandler;
+use App\Lsp\PhpCommandDetector;
+use App\Lsp\Transport\JsonRpcRequest;
+use App\Lsp\Transport\JsonRpcResponse;
+
+/**
+ * A detector that answers from a canned map of commands instead of the shell.
+ */
+function detector(string $environment, array $output = []): PhpCommandDetector
+{
+    $exceptions = new class implements ExceptionHandler
+    {
+        public function report(Throwable $e): void {}
+
+        public function render(JsonRpcRequest $request, Throwable $e): JsonRpcResponse
+        {
+            return JsonRpcResponse::error($request->id(), -32603, $e->getMessage());
+        }
+    };
+
+    return new class('/home/runner/work/project', $environment, $exceptions, $output) extends PhpCommandDetector
+    {
+        public array $ran = [];
+
+        public function __construct(string $path, string $environment, ExceptionHandler $exceptions, protected array $output)
+        {
+            parent::__construct($path, $environment, $exceptions);
+        }
+
+        protected function run(array $command): ?string
+        {
+            $this->ran[] = implode(' ', $command);
+
+            return $this->output[implode(' ', $command)] ?? null;
+        }
+    };
+}
+
+test('resolves the Yerd PHP binary', function () {
+    expect(detector('yerd', [
+        'yerd which php' => "/home/runner/.local/share/yerd/php/php-8.4/bin/php\n",
+    ])->detect())->toBe(['/home/runner/.local/share/yerd/php/php-8.4/bin/php']);
+});
+
+test('falls back to php when Yerd is not installed', function () {
+    expect(detector('yerd')->detect())->toBe(['php']);
+});
+
+test('falls back to php when Yerd resolves nothing', function () {
+    expect(detector('yerd', ['yerd which php' => "  \n"])->detect())->toBe(['php']);
+});
+
+test('resolves the Lerd passthrough command', function () {
+    expect(detector('lerd', [
+        'lerd php -r echo PHP_BINARY;' => '/usr/local/bin/php',
+    ])->detect())->toBe(['lerd', 'php']);
+});
+
+test('falls back to php when Lerd is not installed', function () {
+    expect(detector('lerd')->detect())->toBe(['php']);
+});
+
+test('auto-detection finds Yerd when no other environment answers', function () {
+    $detector = detector('auto', [
+        'yerd which php' => '/home/runner/.local/share/yerd/php/php-8.4/bin/php',
+    ]);
+
+    expect($detector->detect())->toBe(['/home/runner/.local/share/yerd/php/php-8.4/bin/php']);
+});
+
+test('auto-detection finds Lerd when no other environment answers', function () {
+    $detector = detector('auto', [
+        'lerd php -r echo PHP_BINARY;' => '/usr/local/bin/php',
+    ]);
+
+    expect($detector->detect())->toBe(['lerd', 'php']);
+});
+
+test('auto-detection probes Yerd and Lerd before the local binary', function () {
+    $detector = detector('auto');
+
+    $detector->detect();
+
+    $ran = $detector->ran;
+
+    expect(array_search('yerd which php', $ran, true))
+        ->toBeLessThan(array_search('php -r echo PHP_BINARY;', $ran, true))
+        ->and(array_search('lerd php -r echo PHP_BINARY;', $ran, true))
+        ->toBeLessThan(array_search('php -r echo PHP_BINARY;', $ran, true));
+});
+
+test('auto-detection still prefers Herd over Yerd and Lerd', function () {
+    $detector = detector('auto', [
+        'herd which-php'               => '/Users/runner/Library/Application Support/Herd/bin/php84',
+        'yerd which php'               => '/home/runner/.local/share/yerd/php/php-8.4/bin/php',
+        'lerd php -r echo PHP_BINARY;' => '/usr/local/bin/php',
+    ]);
+
+    expect($detector->detect())->toBe(['/Users/runner/Library/Application Support/Herd/bin/php84'])
+        ->and($detector->ran)->not->toContain('yerd which php');
+});


### PR DESCRIPTION
Closes #88.

Adds `yerd` and `lerd` to `PhpCommandDetector`, both as explicit `phpEnvironment` values and as auto-detection steps.

## Why they need different shapes

They are not the same kind of tool, so they do not get the same treatment.

**Yerd** ([yerd.app](https://yerd.app), [forjedio/yerd](https://github.com/forjedio/yerd)) builds native PHP on the host and pins a version per site, so it belongs with Herd and Valet. It ships `yerd which php`, which prints the absolute path of the binary `yerd exec php` would run, resolved from the site the working directory belongs to. The detector already runs its probes with the project root as the working directory, so the path comes back pinned to the right site with no extra flags:

```php
protected function yerd(): array
{
    return $this->binaryCommand($this->run(['yerd', 'which', 'php']));
}
```

**Lerd** ([lerd.sh](https://lerd.sh), [lerd-env/lerd](https://github.com/lerd-env/lerd)) serves every site from a rootless Podman container. `PHP_BINARY` inside that container is `/usr/local/bin/php`, which does not exist on the host, so the binary path is useless and the command has to stay the wrapper. That is exactly the Lando and DDEV shape:

```php
protected function lerd(): array
{
    return $this->run(['lerd', 'php', '-r', 'echo PHP_BINARY;']) === null
        ? ['php']
        : ['lerd', 'php'];
}
```

`lerd php` execs into the container for the site the working directory belongs to, and Lerd bind-mounts the project at the same path, so the relative script path `ScriptRunner` passes to `artisan tinker` resolves unchanged.

## Auto-detection order

```php
foreach (['herd', 'valet', 'sail', 'lando', 'ddev', 'yerd', 'lerd', 'local'] as $environment) {
```

Both are appended after the existing environments, so precedence is unchanged for everyone already using the server. Both go **before** `local`, though, and that placement is load-bearing: Lerd installs a `php` shim on the shell `PATH` that execs into the container, so `php -r 'echo PHP_BINARY;'` under Lerd reports `/usr/local/bin/php`. Probing `local` first would hand back a container path as if it were a host binary and every project script would fail.

## Tests

`tests/Unit/PhpCommandDetectorTest.php` stubs the process runner so the detector can be exercised without either tool installed. It covers the resolved command per environment, the fallback when the tool is absent or resolves an empty path, that both are probed before the local binary, and that Herd still wins auto-detection when several tools answer.

## Note for the VS Code extension

`laravelLsp.phpEnvironment` is an enum in `laravel/vs-code-extension`, so picking these from the settings UI needs `yerd` and `lerd` added there too. They work today via `phpCommand`, and via `phpEnvironment` for clients that do not constrain the value.
