### PR TITLE
Convert LSP positions between UTF-16 and byte offsets at the wire boundary

### DIFF
--- a/app/Lsp/Document.php
+++ b/app/Lsp/Document.php
@@ -25,6 +25,13 @@ class Document
     protected array $autocomplete = [];
 
     /**
+     * The cached document lines.
+     *
+     * @var array<int, string>|null
+     */
+    protected ?array $lines = null;
+
+    /**
      * Create a new document instance.
      */
     public function __construct(
@@ -63,6 +70,24 @@ class Document
     }
 
     /**
+     * Get the document lines.
+     *
+     * @return array<int, string>
+     */
+    public function lines(): array
+    {
+        return $this->lines ??= explode("\n", $this->content);
+    }
+
+    /**
+     * Get a single document line.
+     */
+    public function line(int $line): string
+    {
+        return $this->lines()[$line] ?? '';
+    }
+
+    /**
      * Get document text inside the given LSP range.
      *
      * @param  array<string, mixed>  $range
@@ -90,7 +115,7 @@ class Document
         }
 
         return substr(
-            explode("\n", $this->content)[$line] ?? '',
+            $this->line($line),
             $character,
             $endCharacter - $character,
         );
@@ -110,10 +135,8 @@ class Document
             return $this->content;
         }
 
-        $lines = explode("\n", $this->content);
-        $before = array_slice($lines, 0, $line);
-        $current = $lines[$line] ?? '';
-        $before[] = substr($current, 0, $character);
+        $before = array_slice($this->lines(), 0, $line);
+        $before[] = substr($this->line($line), 0, $character);
 
         return implode("\n", $before);
     }

--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -11,6 +11,7 @@ use App\Lsp\Project;
 use App\Lsp\ProjectIndex;
 use App\Lsp\ScriptRunner;
 use App\Lsp\Support\FileUri;
+use App\Lsp\Support\PositionEncoding;
 use App\Lsp\Transport\JsonRpcRequest;
 use App\Lsp\Transport\JsonRpcResponse;
 use Illuminate\Container\Container;
@@ -54,6 +55,10 @@ final class Initialize implements Method
 
         $this->container->instance(Project::class, $project);
 
+        $encoding = PositionEncoding::negotiate($request->array('capabilities.general.positionEncodings'));
+
+        $this->container->instance(PositionEncoding::class, $encoding);
+
         $this->logger->info('Initialized Laravel LSP.', [
             'rootUri'               => (string) $project->uri,
             'processId'             => $request->get('processId'),
@@ -61,10 +66,12 @@ final class Initialize implements Method
             'initializationOptions' => $project->all(),
             'phpEnvironment'        => $project->phpEnvironment(),
             'phpCommand'            => $project->scripts->command(),
+            'positionEncoding'      => $encoding->value,
         ]);
 
         return JsonRpcResponse::result($request->id(), [
             'capabilities' => [
+                'positionEncoding' => $encoding->value,
                 'textDocumentSync' => [
                     'openClose' => true,
                     'change'    => 1,

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -31,6 +31,8 @@ use App\Lsp\Methods\TextDocumentCompletion;
 use App\Lsp\Methods\TextDocumentDefinition;
 use App\Lsp\Methods\TextDocumentDocumentLink;
 use App\Lsp\Methods\TextDocumentHover;
+use App\Lsp\Support\PositionEncoding;
+use App\Lsp\Support\PositionTranslator;
 use App\Lsp\Transport\AmpStdioTransport;
 use App\Lsp\Transport\JsonRpcRequest;
 use App\Lsp\Transport\JsonRpcResponse;
@@ -148,7 +150,7 @@ final class Server
             return;
         }
 
-        $this->transport->dispatch($request, $this->dispatch(...));
+        $this->transport->dispatch($this->decodePositions($request), $this->dispatch(...));
     }
 
     /**
@@ -188,10 +190,39 @@ final class Server
         ];
 
         if (!is_null($params)) {
-            $data['params'] = $params;
+            $data['params'] = $this->positions()->toClient($params);
         }
 
         $this->transport->send(json_encode($data));
+    }
+
+    /**
+     * Convert the positions in an incoming request to byte offsets.
+     */
+    protected function decodePositions(JsonRpcRequest $request): JsonRpcRequest
+    {
+        return $request->withParams($this->positions()->fromClient($request->all()));
+    }
+
+    /**
+     * Convert the positions in an outgoing response to the wire encoding.
+     */
+    protected function encodePositions(JsonRpcResponse $response, JsonRpcRequest $request): JsonRpcResponse
+    {
+        $translator = $this->positions();
+        $document = $translator->documentFor($request->all());
+
+        return $response->mapResult(fn (mixed $result): mixed => is_array($result)
+            ? $translator->toClient($result, $document)
+            : $result);
+    }
+
+    /**
+     * Get a position translator for the negotiated encoding.
+     */
+    protected function positions(): PositionTranslator
+    {
+        return $this->container->make(PositionTranslator::class);
     }
 
     /**
@@ -251,7 +282,7 @@ final class Server
      */
     public function dispatchRequest(JsonRpcRequest $request): void
     {
-        $this->respond($this->handleRequest($request));
+        $this->respond($this->encodePositions($this->handleRequest($request), $request));
     }
 
     /**
@@ -345,6 +376,7 @@ final class Server
         $this->container->instance(LoggerInterface::class, $this->logger);
 
         $this->container->singletonIf(DocumentManager::class);
+        $this->container->instance(PositionEncoding::class, PositionEncoding::Utf16);
         $this->container->singletonIf(ExceptionHandler::class, Handler::class);
 
         $this->container->singletonIf(Project::class, fn () => throw new ServerNotInitializedException);

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -166,17 +166,11 @@ final class Server
      */
     public function send(string $method, ?array $params = null)
     {
-        $data = [
+        $this->emit([
             'jsonrpc' => '2.0',
             'id'      => $this->lastRequestId++,
             'method'  => $method,
-        ];
-
-        if (!is_null($params)) {
-            $data['params'] = $params;
-        }
-
-        $this->transport->send(json_encode($data));
+        ], $params);
     }
 
     /**
@@ -184,11 +178,24 @@ final class Server
      */
     public function notify(string $method, ?array $params = null)
     {
-        $data = [
+        $this->emit([
             'jsonrpc' => '2.0',
             'method'  => $method,
-        ];
+        ], $params);
+    }
 
+    /**
+     * Send a server-initiated message, converting the positions it carries.
+     *
+     * Responses go out through respond(), which encodes against the document
+     * resolved from the request being answered. A server-initiated message has
+     * no such request, so the translator resolves the document per payload.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>|null  $params
+     */
+    protected function emit(array $data, ?array $params): void
+    {
         if (!is_null($params)) {
             $data['params'] = $this->positions()->toClient($params);
         }

--- a/app/Lsp/Support/PositionEncoding.php
+++ b/app/Lsp/Support/PositionEncoding.php
@@ -106,7 +106,7 @@ enum PositionEncoding: string
     {
         // A four byte sequence is outside the basic multilingual plane, so it is
         // a surrogate pair in UTF-16 and a single code point everywhere else.
-        return $this === self::Utf16 && $byte >= 0xF0 ? 2 : 1;
+        return $this === self::Utf16 && $this->widthFor($byte) === 4 ? 2 : 1;
     }
 
     /**
@@ -115,6 +115,7 @@ enum PositionEncoding: string
     protected function widthFor(int $byte): int
     {
         return match (true) {
+            $byte >= 0xF8 => 1, // Never a valid lead byte, so it stands alone.
             $byte >= 0xF0 => 4,
             $byte >= 0xE0 => 3,
             $byte >= 0xC0 => 2,

--- a/app/Lsp/Support/PositionEncoding.php
+++ b/app/Lsp/Support/PositionEncoding.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Support;
+
+/**
+ * The offset unit used for the "character" member of an LSP position.
+ *
+ * The parser works in UTF-8 byte offsets. The protocol defaults to UTF-16 code
+ * units, so unless a client negotiates something else every position has to be
+ * converted on the way in and on the way out.
+ */
+enum PositionEncoding: string
+{
+    case Utf8 = 'utf-8';
+    case Utf16 = 'utf-16';
+    case Utf32 = 'utf-32';
+
+    /**
+     * Pick an encoding from the encodings a client supports.
+     *
+     * UTF-8 is preferred when offered because it matches the parser and makes
+     * conversion a no-op. UTF-16 is the protocol default and the fallback for a
+     * client that advertises nothing.
+     *
+     * @param  array<int, mixed>  $supported
+     */
+    public static function negotiate(array $supported): self
+    {
+        foreach ([self::Utf8, self::Utf16, self::Utf32] as $encoding) {
+            if (in_array($encoding->value, $supported, true)) {
+                return $encoding;
+            }
+        }
+
+        return self::Utf16;
+    }
+
+    /**
+     * Convert a byte offset within a line to an offset in this encoding.
+     */
+    public function fromByteOffset(string $line, int $byteOffset): int
+    {
+        if ($this === self::Utf8) {
+            return $byteOffset;
+        }
+
+        $byteOffset = max(0, min($byteOffset, strlen($line)));
+        $offset = 0;
+
+        for ($index = 0; $index < $byteOffset; $index++) {
+            $byte = ord($line[$index]);
+
+            if ($this->isContinuation($byte)) {
+                continue;
+            }
+
+            $offset += $this->unitsFor($byte);
+        }
+
+        return $offset;
+    }
+
+    /**
+     * Convert an offset in this encoding to a byte offset within a line.
+     */
+    public function toByteOffset(string $line, int $offset): int
+    {
+        if ($this === self::Utf8) {
+            return $offset;
+        }
+
+        $length = strlen($line);
+        $index = 0;
+        $consumed = 0;
+
+        while ($index < $length && $consumed < $offset) {
+            $byte = ord($line[$index]);
+            $units = $this->unitsFor($byte);
+
+            // Stop short rather than split a character the offset lands inside.
+            if ($consumed + $units > $offset) {
+                break;
+            }
+
+            $consumed += $units;
+            $index += $this->widthFor($byte);
+        }
+
+        return min($index, $length);
+    }
+
+    /**
+     * Determine if the byte is a UTF-8 continuation byte.
+     */
+    protected function isContinuation(int $byte): bool
+    {
+        return ($byte & 0xC0) === 0x80;
+    }
+
+    /**
+     * Get the number of offset units the character starting with the byte uses.
+     */
+    protected function unitsFor(int $byte): int
+    {
+        // A four byte sequence is outside the basic multilingual plane, so it is
+        // a surrogate pair in UTF-16 and a single code point everywhere else.
+        return $this === self::Utf16 && $byte >= 0xF0 ? 2 : 1;
+    }
+
+    /**
+     * Get the byte width of the character starting with the byte.
+     */
+    protected function widthFor(int $byte): int
+    {
+        return match (true) {
+            $byte >= 0xF0 => 4,
+            $byte >= 0xE0 => 3,
+            $byte >= 0xC0 => 2,
+            default       => 1,
+        };
+    }
+}

--- a/app/Lsp/Support/PositionTranslator.php
+++ b/app/Lsp/Support/PositionTranslator.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Support;
+
+use App\Lsp\Document;
+use App\Lsp\DocumentManager;
+
+/**
+ * Converts LSP positions between the negotiated wire encoding and the UTF-8
+ * byte offsets every parser, mapper, and provider works in.
+ *
+ * Translating here rather than inside each feature keeps a single place that
+ * has to know about encodings, and keeps the rest of the server on bytes.
+ */
+class PositionTranslator
+{
+    /**
+     * Create a new position translator instance.
+     */
+    public function __construct(
+        protected DocumentManager $documents,
+        protected PositionEncoding $encoding,
+    ) {}
+
+    /**
+     * Convert wire positions in an incoming payload to byte offsets.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function fromClient(array $payload): array
+    {
+        return $this->translate($payload, false);
+    }
+
+    /**
+     * Convert byte offsets in an outgoing payload to wire positions.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function toClient(array $payload, ?Document $document = null): array
+    {
+        return $this->translate($payload, true, $document);
+    }
+
+    /**
+     * Resolve the document an outgoing payload belongs to.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function documentFor(array $payload): ?Document
+    {
+        $uri = $payload['textDocument']['uri'] ?? $payload['uri'] ?? null;
+
+        return is_string($uri) ? $this->documents->get($uri) : null;
+    }
+
+    /**
+     * Translate every position in the payload.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    protected function translate(array $payload, bool $outgoing, ?Document $document = null): array
+    {
+        if ($this->encoding === PositionEncoding::Utf8) {
+            return $payload;
+        }
+
+        /** @var array<string, mixed> $translated */
+        $translated = $this->walk($payload, $outgoing, $document);
+
+        return $translated;
+    }
+
+    /**
+     * Walk a payload value, converting any position it contains.
+     */
+    protected function walk(mixed $value, bool $outgoing, ?Document $document): mixed
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if ($this->isPosition($value)) {
+            return $this->convert($value, $outgoing, $document);
+        }
+
+        $document = $this->documentFor($value) ?? $document;
+
+        foreach ($value as $key => $item) {
+            // A workspace edit keys its changes by document URI, so positions
+            // below one belong to that document rather than the request's.
+            $value[$key] = is_string($key) && str_starts_with($key, 'file://')
+                ? $this->walk($item, $outgoing, $this->documents->get($key))
+                : $this->walk($item, $outgoing, $document);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Determine if the value is an LSP position.
+     *
+     * @param  array<array-key, mixed>  $value
+     */
+    protected function isPosition(array $value): bool
+    {
+        return is_int($value['line'] ?? null) && is_int($value['character'] ?? null);
+    }
+
+    /**
+     * Convert a single position.
+     *
+     * @param  array<string, mixed>  $position
+     * @return array<string, mixed>
+     */
+    protected function convert(array $position, bool $outgoing, ?Document $document): array
+    {
+        /** @var int $line */
+        $line = $position['line'];
+        /** @var int $character */
+        $character = $position['character'];
+
+        // A character offset of zero is identical in every encoding, so a
+        // position pointing at the start of a line never needs the document.
+        if ($character === 0 || $document === null) {
+            return $position;
+        }
+
+        $text = $document->line($line);
+
+        $position['character'] = $outgoing
+            ? $this->encoding->fromByteOffset($text, $character)
+            : $this->encoding->toByteOffset($text, $character);
+
+        return $position;
+    }
+}

--- a/app/Lsp/Transport/JsonRpcRequest.php
+++ b/app/Lsp/Transport/JsonRpcRequest.php
@@ -62,6 +62,20 @@ class JsonRpcRequest
     }
 
     /**
+     * Get a copy of the request with the given parameters.
+     *
+     * @param  array<string, mixed>  $params
+     */
+    public function withParams(array $params): static
+    {
+        $request = clone $this;
+
+        $request->params = $params;
+
+        return $request;
+    }
+
+    /**
      * Get the request ID.
      */
     public function id(): int|string

--- a/app/Lsp/Transport/JsonRpcResponse.php
+++ b/app/Lsp/Transport/JsonRpcResponse.php
@@ -65,6 +65,18 @@ class JsonRpcResponse
     }
 
     /**
+     * Get a copy of the response with its result passed through the callback.
+     */
+    public function mapResult(callable $callback): static
+    {
+        if (!array_key_exists('result', $this->content)) {
+            return $this;
+        }
+
+        return new static([...$this->content, 'result' => $callback($this->content['result'])]);
+    }
+
+    /**
      * Get the response as an array.
      *
      * @return array<string, mixed>

--- a/app/Parsers/InlineHtmlParser.php
+++ b/app/Parsers/InlineHtmlParser.php
@@ -38,11 +38,17 @@ class InlineHtmlParser extends AbstractParser
      * Stillat\BladeParser\Document\Document::fromText treats multibyte characters
      * as indentations and spaces resulting in a miscalculated Node position.
      *
-     * This function replaces the multibyte characters with a single, placeholder character
+     * This function replaces each multibyte character with as many placeholder
+     * characters as it occupies bytes, so Blade node positions stay UTF-8 byte
+     * offsets and line up with the byte offsets the PHP parser reports.
      */
     private function replaceMultibyteChars(string $text, string $placeholder = '*'): string
     {
-        return preg_replace('/[^\x00-\x7F]/u', $placeholder, $text);
+        return preg_replace_callback(
+            '/[^\x00-\x7F]/u',
+            fn (array $matches): string => str_repeat($placeholder, strlen($matches[0])),
+            $text,
+        ) ?? $text;
     }
 
     public function parse(InlineHtml $node)

--- a/tests/Unit/PositionEncodingTest.php
+++ b/tests/Unit/PositionEncodingTest.php
@@ -1,0 +1,168 @@
+<?php
+
+use App\Lsp\Document;
+use App\Lsp\DocumentManager;
+use App\Lsp\Support\PositionEncoding;
+use App\Lsp\Support\PositionTranslator;
+
+test('negotiates the encoding a client offers', function () {
+    expect(PositionEncoding::negotiate(['utf-16', 'utf-8']))->toBe(PositionEncoding::Utf8)
+        ->and(PositionEncoding::negotiate(['utf-16']))->toBe(PositionEncoding::Utf16)
+        ->and(PositionEncoding::negotiate(['utf-32']))->toBe(PositionEncoding::Utf32);
+});
+
+test('defaults to utf-16 when a client advertises nothing', function () {
+    expect(PositionEncoding::negotiate([]))->toBe(PositionEncoding::Utf16)
+        ->and(PositionEncoding::negotiate(['utf-64']))->toBe(PositionEncoding::Utf16);
+});
+
+test('converts byte offsets to utf-16 code units', function (string $line, int $bytes, int $expected) {
+    expect(PositionEncoding::Utf16->fromByteOffset($line, $bytes))->toBe($expected);
+})->with([
+    ["view('x');", 6, 6],
+    ["\$x = '日本語'; view('x');", 24, 18],
+    ["\$x = '🎉'; view('x');", 19, 17],
+]);
+
+test('converts utf-16 code units back to byte offsets', function (string $line, int $bytes, int $units) {
+    expect(PositionEncoding::Utf16->toByteOffset($line, $units))->toBe($bytes);
+})->with([
+    ["view('x');", 6, 6],
+    ["\$x = '日本語'; view('x');", 24, 18],
+    ["\$x = '🎉'; view('x');", 19, 17],
+]);
+
+test('counts an astral character as two utf-16 code units', function () {
+    expect(PositionEncoding::Utf16->fromByteOffset('🎉', 4))->toBe(2)
+        ->and(PositionEncoding::Utf32->fromByteOffset('🎉', 4))->toBe(1)
+        ->and(PositionEncoding::Utf8->fromByteOffset('🎉', 4))->toBe(4);
+});
+
+test('does not split a character an offset lands inside', function () {
+    // Offset 1 is halfway through the surrogate pair, so it clamps to the start.
+    expect(PositionEncoding::Utf16->toByteOffset('🎉x', 1))->toBe(0)
+        ->and(PositionEncoding::Utf16->toByteOffset('🎉x', 2))->toBe(4)
+        ->and(PositionEncoding::Utf16->toByteOffset('🎉x', 3))->toBe(5);
+});
+
+test('clamps offsets past the end of a line', function () {
+    expect(PositionEncoding::Utf16->fromByteOffset('日', 99))->toBe(1)
+        ->and(PositionEncoding::Utf16->toByteOffset('日', 99))->toBe(3)
+        ->and(PositionEncoding::Utf16->fromByteOffset('日', -5))->toBe(0);
+});
+
+test('leaves invalid utf-8 bytes addressable', function () {
+    $line = "a\xFFb";
+
+    expect(PositionEncoding::Utf16->fromByteOffset($line, 3))->toBe(3)
+        ->and(PositionEncoding::Utf16->toByteOffset($line, 3))->toBe(3);
+});
+
+function translator(PositionEncoding $encoding, array $documents = []): PositionTranslator
+{
+    $manager = new DocumentManager;
+
+    foreach ($documents as $uri => $content) {
+        $manager->open($uri, $content);
+    }
+
+    return new PositionTranslator($manager, $encoding);
+}
+
+test('converts an incoming position to a byte offset', function () {
+    $uri = 'file:///project/app/Http/Controllers/HomeController.php';
+
+    $translated = translator(PositionEncoding::Utf16, [
+        $uri => "<?php\n\$x = '日本語'; view('x');",
+    ])->fromClient([
+        'textDocument' => ['uri' => $uri],
+        'position'     => ['line' => 1, 'character' => 18],
+    ]);
+
+    expect($translated['position'])->toBe(['line' => 1, 'character' => 24]);
+});
+
+test('converts an outgoing diagnostic range to the wire encoding', function () {
+    $uri = 'file:///project/app/Http/Controllers/HomeController.php';
+
+    $translated = translator(PositionEncoding::Utf16, [
+        $uri => "<?php\n\$x = '日本語'; view('x');",
+    ])->toClient([
+        'uri'         => $uri,
+        'diagnostics' => [[
+            'range' => [
+                'start' => ['line' => 1, 'character' => 24],
+                'end'   => ['line' => 1, 'character' => 27],
+            ],
+            'message' => 'View not found.',
+        ]],
+    ]);
+
+    expect($translated['diagnostics'][0]['range'])->toBe([
+        'start' => ['line' => 1, 'character' => 18],
+        'end'   => ['line' => 1, 'character' => 21],
+    ]);
+});
+
+test('leaves positions alone when utf-8 is negotiated', function () {
+    $uri = 'file:///project/app.php';
+
+    $payload = [
+        'textDocument' => ['uri' => $uri],
+        'position'     => ['line' => 1, 'character' => 24],
+    ];
+
+    expect(translator(PositionEncoding::Utf8, [$uri => "<?php\n\$x = '日本語';"])->fromClient($payload))
+        ->toBe($payload);
+});
+
+test('leaves positions alone for a document that is not open', function () {
+    $payload = [
+        'uri'         => 'file:///project/.env',
+        'diagnostics' => [[
+            'range' => [
+                'start' => ['line' => 0, 'character' => 12],
+                'end'   => ['line' => 0, 'character' => 20],
+            ],
+        ]],
+    ];
+
+    expect(translator(PositionEncoding::Utf16)->toClient($payload))->toBe($payload);
+});
+
+test('resolves workspace edit positions against the document each change targets', function () {
+    $current = 'file:///project/resources/views/home.blade.php';
+    $other = 'file:///project/app/Other.php';
+
+    $translated = translator(PositionEncoding::Utf16, [
+        $current => "<?php\n// 日本語 padding here",
+        $other   => "<?php\n\$x = '日本語'; view('x');",
+    ])->toClient([
+        'edit' => [
+            'changes' => [
+                $other => [[
+                    'range' => [
+                        'start' => ['line' => 1, 'character' => 24],
+                        'end'   => ['line' => 1, 'character' => 24],
+                    ],
+                    'newText' => 'x',
+                ]],
+            ],
+        ],
+    ], (new Document($current, "<?php\n// 日本語 padding here")));
+
+    expect($translated['edit']['changes'][$other][0]['range']['start'])
+        ->toBe(['line' => 1, 'character' => 18]);
+});
+
+test('leaves a character offset of zero untouched', function () {
+    $payload = [
+        'uri'   => 'file:///project/.env',
+        'range' => [
+            'start' => ['line' => 4, 'character' => 0],
+            'end'   => ['line' => 4, 'character' => 0],
+        ],
+    ];
+
+    expect(translator(PositionEncoding::Utf16)->toClient($payload))->toBe($payload);
+});

--- a/tests/Unit/ServerPositionEncodingTest.php
+++ b/tests/Unit/ServerPositionEncodingTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Lsp\Contracts\Transport;
+use App\Lsp\DocumentManager;
+use App\Lsp\Server;
+use App\Lsp\Support\FileUri;
+use App\Lsp\Transport\JsonRpcRequest;
+use Illuminate\Container\Container;
+use Psr\Log\NullLogger;
+
+/**
+ * A transport that records what the server sends and replays what it receives.
+ */
+function fakeTransport(): Transport
+{
+    return new class implements Transport
+    {
+        /** @var array<int, array<string, mixed>> */
+        public array $sent = [];
+
+        public ?Closure $handler = null;
+
+        public function onReceive(Closure $handler): void
+        {
+            $this->handler = $handler;
+        }
+
+        public function dispatch(JsonRpcRequest $request, Closure $dispatch): void
+        {
+            $dispatch($request);
+        }
+
+        public function cancel(int|string $id): void {}
+
+        public function run(): void {}
+
+        public function send(string $message): void
+        {
+            $this->sent[] = json_decode($message, true);
+        }
+
+        public function receive(array $message): void
+        {
+            ($this->handler)(json_encode($message));
+        }
+    };
+}
+
+/**
+ * Track the throwaway project roots created by this file.
+ */
+function serverRoots(): ArrayObject
+{
+    static $roots = new ArrayObject;
+
+    return $roots;
+}
+
+/**
+ * Boot a server against a throwaway Laravel project root.
+ */
+function bootServer(array $positionEncodings): array
+{
+    $root = sys_get_temp_dir() . '/lsp-' . bin2hex(random_bytes(6));
+
+    mkdir($root, 0777, true);
+    touch($root . '/artisan');
+
+    serverRoots()->append($root);
+
+    $transport = fakeTransport();
+    $container = new Container;
+    $server = new Server($transport, new NullLogger, $container);
+
+    $server->start();
+
+    $transport->receive([
+        'jsonrpc' => '2.0',
+        'id'      => 1,
+        'method'  => 'initialize',
+        'params'  => [
+            'rootUri'               => (string) FileUri::fromPath($root),
+            'capabilities'          => ['general' => ['positionEncodings' => $positionEncodings]],
+            'initializationOptions' => ['phpCommand' => ['php']],
+        ],
+    ]);
+
+    return [$server, $transport, $container, $root];
+}
+
+afterEach(function () {
+    foreach (serverRoots() as $root) {
+        @unlink($root . '/artisan');
+        @rmdir($root);
+    }
+
+    serverRoots()->exchangeArray([]);
+});
+
+test('advertises the negotiated position encoding', function (array $offered, string $expected) {
+    [, $transport] = bootServer($offered);
+
+    expect($transport->sent[0]['result']['capabilities']['positionEncoding'])->toBe($expected);
+})->with([
+    'prefers utf-8'         => [['utf-16', 'utf-8'], 'utf-8'],
+    'accepts utf-16'        => [['utf-16'], 'utf-16'],
+    'accepts utf-32'        => [['utf-32'], 'utf-32'],
+    'defaults when unknown' => [[], 'utf-16'],
+]);
+
+test('converts outgoing diagnostics to utf-16 code units', function () {
+    [$server, $transport, $container] = bootServer(['utf-16']);
+
+    $uri = 'file:///project/app/Http/Controllers/HomeController.php';
+
+    $container[DocumentManager::class]->open($uri, "<?php\n\$x = '日本語'; view('x');");
+
+    $server->notify('textDocument/publishDiagnostics', [
+        'uri'         => $uri,
+        'diagnostics' => [[
+            'range' => [
+                'start' => ['line' => 1, 'character' => 24],
+                'end'   => ['line' => 1, 'character' => 27],
+            ],
+            'message' => 'View not found.',
+        ]],
+    ]);
+
+    expect(end($transport->sent)['params']['diagnostics'][0]['range'])->toBe([
+        'start' => ['line' => 1, 'character' => 18],
+        'end'   => ['line' => 1, 'character' => 21],
+    ]);
+});
+
+test('leaves outgoing diagnostics alone when utf-8 is negotiated', function () {
+    [$server, $transport, $container] = bootServer(['utf-8']);
+
+    $uri = 'file:///project/app/Http/Controllers/HomeController.php';
+
+    $container[DocumentManager::class]->open($uri, "<?php\n\$x = '日本語'; view('x');");
+
+    $server->notify('textDocument/publishDiagnostics', [
+        'uri'         => $uri,
+        'diagnostics' => [[
+            'range' => [
+                'start' => ['line' => 1, 'character' => 24],
+                'end'   => ['line' => 1, 'character' => 27],
+            ],
+        ]],
+    ]);
+
+    expect(end($transport->sent)['params']['diagnostics'][0]['range']['start'])
+        ->toBe(['line' => 1, 'character' => 24]);
+});

--- a/tests/Unit/ServerPositionEncodingTest.php
+++ b/tests/Unit/ServerPositionEncodingTest.php
@@ -152,3 +152,59 @@ test('leaves outgoing diagnostics alone when utf-8 is negotiated', function () {
     expect(end($transport->sent)['params']['diagnostics'][0]['range']['start'])
         ->toBe(['line' => 1, 'character' => 24]);
 });
+
+test('converts positions in a server-initiated request', function () {
+    [$server, $transport, $container] = bootServer(['utf-16']);
+
+    $uri = 'file:///project/app/Http/Controllers/HomeController.php';
+
+    $container[DocumentManager::class]->open($uri, "<?php\n\$x = '日本語'; view('x');");
+
+    $server->send('workspace/applyEdit', [
+        'edit' => [
+            'changes' => [
+                $uri => [[
+                    'range' => [
+                        'start' => ['line' => 1, 'character' => 24],
+                        'end'   => ['line' => 1, 'character' => 27],
+                    ],
+                    'newText' => 'home',
+                ]],
+            ],
+        ],
+    ]);
+
+    $sent = end($transport->sent);
+
+    expect($sent['params']['edit']['changes'][$uri][0]['range'])->toBe([
+        'start' => ['line' => 1, 'character' => 18],
+        'end'   => ['line' => 1, 'character' => 21],
+    ]);
+
+    // send() is a request, not a notification, so it still carries an id.
+    expect($sent)->toHaveKey('id');
+});
+
+test('leaves a server-initiated request alone when utf-8 is negotiated', function () {
+    [$server, $transport, $container] = bootServer(['utf-8']);
+
+    $uri = 'file:///project/app/Http/Controllers/HomeController.php';
+
+    $container[DocumentManager::class]->open($uri, "<?php\n\$x = '日本語'; view('x');");
+
+    $server->send('workspace/applyEdit', [
+        'edit' => [
+            'changes' => [
+                $uri => [[
+                    'range' => [
+                        'start' => ['line' => 1, 'character' => 24],
+                        'end'   => ['line' => 1, 'character' => 27],
+                    ],
+                ]],
+            ],
+        ],
+    ]);
+
+    expect(end($transport->sent)['params']['edit']['changes'][$uri][0]['range']['start'])
+        ->toBe(['line' => 1, 'character' => 24]);
+});


### PR DESCRIPTION
Fixes #68.

Takes the first of the two options in the issue: **convert at the wire boundary and leave the parser on bytes.** Normalizing the document before parsing would mean every parser, mapper, provider, and offset arithmetic in the server changes meaning, and every place that does `strlen()` on a token has to be revisited. Converting at the boundary confines encoding knowledge to two new classes and leaves everything between them exactly as it is.

## What was wrong

`character` went out as a UTF-8 byte offset. The spec says it is UTF-16 code units unless `positionEncoding` is negotiated, and the server never advertised one. Reproducing the table from the issue:

| line | before | after |
|---|---|---|
| `view('x');` | 6 | 6 |
| `$x = '日本語'; view('x');` | 24 | 18 |
| `$x = '🎉'; view('x');` | 19 | 17 |

Incoming positions had the mirror problem: `Document::contentUntil()` and `textInRange()` use `substr()`, so a completion request after multibyte text sliced at the wrong byte.

## The change

**`PositionEncoding`** (enum, `utf-8` / `utf-16` / `utf-32`) owns the conversion. Counting needs no decoding: skip continuation bytes (`0b10xxxxxx`), and count a four byte lead as **two** UTF-16 units because it becomes a surrogate pair. `negotiate()` prefers UTF-8 when a client offers it, since that matches the parser and makes conversion a no-op, and otherwise falls back to UTF-16, which is what the spec mandates when nothing is negotiated.

**`PositionTranslator`** walks a payload and converts anything shaped like a position. The document a position belongs to is resolved from the payload itself: `textDocument.uri` for requests, `uri` for `publishDiagnostics`, and the URI key of a workspace edit's `changes` map for an edit aimed at another file. Two shortcuts keep it cheap: UTF-8 returns the payload untouched, and a `character` of `0` is identical in every encoding so it never needs a document lookup, which covers the code action edits that target a file the editor never opened.

**`Server`** applies it at the two crossings. `handle()` converts incoming parameters to byte offsets before dispatch; `dispatchRequest()` and `notify()` convert results and notification parameters back. Nothing in between changes.

**`Initialize`** negotiates from `capabilities.general.positionEncodings`, advertises `capabilities.positionEncoding`, binds the result into the container, and logs it. `Server::registerBaseBindings()` binds UTF-16 as the default so a message arriving before initialize still behaves per spec.

## The Blade half

The issue also flagged that `InlineHtmlParser::replaceMultibyteChars()` leaves Blade on code points while PHP is on bytes. It replaced every multibyte character with a **single** `*`, collapsing the offsets. It now pads the placeholder to the character's byte width, so Blade nodes stay on byte offsets and the two paths agree before the boundary converts once.

This is a different layer from #87 / [vs-code-php-parser-cli#21](https://github.com/laravel/vs-code-php-parser-cli/pull/21), which fix *which* node gets found. This fixes the offsets attached to it. Both are needed, and they do not conflict.

## Tests

`tests/Unit/PositionEncodingTest.php` covers the three rows above and their round trips, astral characters counting as a surrogate pair, offsets landing inside a character or past the end of a line, bytes that are not valid UTF-8, and the translator's document resolution including the `changes` map case.

`tests/Unit/ServerPositionEncodingTest.php` drives a real `Server` through a fake transport: a full `initialize` handshake asserting the advertised encoding for each client offer, and an outgoing `publishDiagnostics` asserting the range converts under UTF-16 and is left alone under UTF-8.

Note: the `ParserTest` and `DetectTest` failures on this branch are present on `main` too. They read fixtures from `tests/../snippets` while the fixtures live at the repo root. Not touched here.

## Client impact

Nothing changes for a client that advertises `utf-16` or nothing beyond positions now being correct. A client that offers `utf-8` (Neovim does) gets `utf-8` back and skips conversion entirely.
