### PR TITLE
Add workspace reference search for Laravel symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Editor clients pass configuration through the LSP `initializationOptions` object
 | `phpEnvironment`        | `string`   | `"auto"`                                | Select the environment used to detect the PHP command for indexing project data.                         |
 | `phpCommand`            | `string[]` | Detected from `phpEnvironment`          | Use an explicit command and arguments, such as `["php"]` or `["./vendor/bin/sail", "php"]`.              |
 | `definitionProvider`    | `boolean`  | `true`                                  | Advertise definition support to the editor. Definitions are resolved from enabled document link options. |
+| `referencesProvider`    | `boolean`  | `true`                                  | Advertise reference support to the editor. References are searched across the workspace.                 |
 | `pestGenerateDocBlocks` | `boolean`  | `true`                                  | Generate Pest helper docblocks and keep them updated when tests or Composer autoload files change.       |
 | `pestHelperFilePath`    | `string`   | `"storage/framework/testing/_pest.php"` | Set the Pest helper output path relative to the Laravel project root.                                    |
 
@@ -118,6 +119,23 @@ The `phpEnvironment` option controls which PHP command is used when the server r
 If detection fails, or an unknown value is provided, the server falls back to `php`.
 
 When `phpCommand` is a non-empty array, it takes precedence over `phpEnvironment`.
+
+### Finding References
+
+With `referencesProvider` enabled, `textDocument/references` reports every place in the workspace that uses the Laravel symbol under the cursor. Put the cursor inside a route name, view name, config key, or translation key and the server returns each other use of that same name, across both PHP and Blade files.
+
+The search is limited to files whose contents contain the exact symbol, and `vendor`, `node_modules`, `storage`, and build output are never searched.
+
+These are usages, not declarations. Asking for references to `users.index` from `route('users.index')` finds the other calls that build that URL, not the `->name('users.index')` that declares it.
+
+Each feature has its own option, so an individual symbol type can be left out of the search:
+
+| Option                   | Description                             |
+| ------------------------ | --------------------------------------- |
+| `routeReferences`        | Search for uses of a route name.        |
+| `viewReferences`         | Search for uses of a view name.         |
+| `configReferences`       | Search for uses of a config key.        |
+| `translationReferences`  | Search for uses of a translation key.   |
 
 ### Feature Options
 

--- a/app/Lsp/Contracts/ReferenceProvider.php
+++ b/app/Lsp/Contracts/ReferenceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Contracts;
+
+use App\Lsp\Document;
+
+interface ReferenceProvider
+{
+    /**
+     * Get the symbol this provider owns at the given position, if any.
+     *
+     * @param  array<string, mixed>  $position
+     */
+    public function symbolAt(Document $document, array $position): ?string;
+
+    /**
+     * Get the ranges in the document that reference the given symbol.
+     *
+     * @return array<int, array<string, array<string, int>>>
+     */
+    public function ranges(Document $document, string $symbol): array;
+}

--- a/app/Lsp/FeatureRegistry.php
+++ b/app/Lsp/FeatureRegistry.php
@@ -10,6 +10,7 @@ use App\Lsp\Contracts\DiagnosticProvider;
 use App\Lsp\Contracts\FileWatcher;
 use App\Lsp\Contracts\HoverProvider;
 use App\Lsp\Contracts\LinkProvider;
+use App\Lsp\Contracts\ReferenceProvider;
 use App\Lsp\Features\AppBindings\AppBindingCompletionProvider;
 use App\Lsp\Features\AppBindings\AppBindingDiagnosticProvider;
 use App\Lsp\Features\AppBindings\AppBindingHoverProvider;
@@ -29,6 +30,7 @@ use App\Lsp\Features\Configs\ConfigCompletionProvider;
 use App\Lsp\Features\Configs\ConfigDiagnosticProvider;
 use App\Lsp\Features\Configs\ConfigHoverProvider;
 use App\Lsp\Features\Configs\ConfigLinkProvider;
+use App\Lsp\Features\Configs\ConfigReferenceProvider;
 use App\Lsp\Features\ControllerActions\ControllerActionCompletionProvider;
 use App\Lsp\Features\ControllerActions\ControllerActionDiagnosticProvider;
 use App\Lsp\Features\ControllerActions\ControllerActionLinkProvider;
@@ -61,6 +63,7 @@ use App\Lsp\Features\Routes\RouteDiagnosticProvider;
 use App\Lsp\Features\Routes\RouteHoverProvider;
 use App\Lsp\Features\Routes\RouteLinkProvider;
 use App\Lsp\Features\Routes\RouteParameterCompletionProvider;
+use App\Lsp\Features\Routes\RouteReferenceProvider;
 use App\Lsp\Features\Storage\StorageCompletionProvider;
 use App\Lsp\Features\Storage\StorageDiagnosticProvider;
 use App\Lsp\Features\Storage\StorageLinkProvider;
@@ -70,6 +73,7 @@ use App\Lsp\Features\Translations\TranslationHoverProvider;
 use App\Lsp\Features\Translations\TranslationLinkProvider;
 use App\Lsp\Features\Translations\TranslationLocaleCompletionProvider;
 use App\Lsp\Features\Translations\TranslationParameterCompletionProvider;
+use App\Lsp\Features\Translations\TranslationReferenceProvider;
 use App\Lsp\Features\Validation\ValidationCompletionProvider;
 use App\Lsp\Features\Views\ViewCodeActionProvider;
 use App\Lsp\Features\Views\ViewCompletionProvider;
@@ -77,6 +81,7 @@ use App\Lsp\Features\Views\ViewContentCompletionProvider;
 use App\Lsp\Features\Views\ViewDiagnosticProvider;
 use App\Lsp\Features\Views\ViewHoverProvider;
 use App\Lsp\Features\Views\ViewLinkProvider;
+use App\Lsp\Features\Views\ViewReferenceProvider;
 use App\Lsp\Watchers\DataProviderWatcher;
 use App\Lsp\Watchers\PestHelperWatcher;
 use Illuminate\Container\Container;
@@ -191,6 +196,18 @@ class FeatureRegistry
     ];
 
     /**
+     * Reference providers.
+     *
+     * @var array<int, class-string<ReferenceProvider>>
+     */
+    public array $references = [
+        RouteReferenceProvider::class,
+        ViewReferenceProvider::class,
+        ConfigReferenceProvider::class,
+        TranslationReferenceProvider::class,
+    ];
+
+    /**
      * File watchers.
      *
      * @var array<int, class-string<FileWatcher>>
@@ -249,6 +266,16 @@ class FeatureRegistry
     }
 
     /**
+     * Resolve reference providers.
+     *
+     * @return array<int, ReferenceProvider>
+     */
+    public function references(): array
+    {
+        return $this->resolve($this->references);
+    }
+
+    /**
      * Resolve file watcher providers.
      *
      * @return array<int, FileWatcher>
@@ -271,7 +298,7 @@ class FeatureRegistry
     /**
      * Resolve given classes from the container.
      *
-     * @param array<int, class-string> $classes
+     * @param  array<int, class-string>  $classes
      * @return array<int, mixed>
      */
     protected function resolve(array $classes): array

--- a/app/Lsp/Features/Configs/ConfigReferenceProvider.php
+++ b/app/Lsp/Features/Configs/ConfigReferenceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Features\Configs;
+
+use App\Lsp\Features\Support\DocumentMapper;
+use App\Lsp\Features\Support\ReferenceFeature;
+
+class ConfigReferenceProvider extends ReferenceFeature
+{
+    /**
+     * Get the mapper that detects config symbols.
+     */
+    protected function mapper(): DocumentMapper
+    {
+        return new ConfigDocumentMapper($this->project);
+    }
+
+    /**
+     * Get the initialization option that enables config references.
+     */
+    protected function option(): string
+    {
+        return 'configReferences';
+    }
+}

--- a/app/Lsp/Features/Routes/RouteReferenceProvider.php
+++ b/app/Lsp/Features/Routes/RouteReferenceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Features\Routes;
+
+use App\Lsp\Features\Support\DocumentMapper;
+use App\Lsp\Features\Support\ReferenceFeature;
+
+class RouteReferenceProvider extends ReferenceFeature
+{
+    /**
+     * Get the mapper that detects route symbols.
+     */
+    protected function mapper(): DocumentMapper
+    {
+        return new RouteDocumentMapper($this->project);
+    }
+
+    /**
+     * Get the initialization option that enables route references.
+     */
+    protected function option(): string
+    {
+        return 'routeReferences';
+    }
+}

--- a/app/Lsp/Features/Support/DocumentMapper.php
+++ b/app/Lsp/Features/Support/DocumentMapper.php
@@ -10,6 +10,7 @@ use App\Lsp\Detection\DetectedArgument;
 use App\Lsp\Detection\DetectedArguments;
 use App\Lsp\Detection\Pattern;
 use App\Lsp\Document;
+use App\Lsp\Support\Position;
 use Illuminate\Support\Collection;
 
 abstract class DocumentMapper
@@ -95,6 +96,44 @@ abstract class DocumentMapper
     {
         return $this->arguments($document)
             ->first(fn (DetectedArgument $argument): bool => $argument->containsPosition($position));
+    }
+
+    /**
+     * Get the symbol at the given position.
+     *
+     * @param  array<string, mixed>  $position
+     */
+    public function symbolAt(Document $document, array $position): ?string
+    {
+        foreach ($this->arguments($document) as $argument) {
+            foreach ($argument->stringValues() as $value) {
+                if (Position::inRange($value['range'], $position)) {
+                    return $value['value'];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the ranges of every detected string matching the given symbol.
+     *
+     * @return array<int, array<string, array<string, int>>>
+     */
+    public function rangesFor(Document $document, string $symbol): array
+    {
+        $ranges = [];
+
+        foreach ($this->arguments($document) as $argument) {
+            foreach ($argument->stringValues() as $value) {
+                if ($value['value'] === $symbol) {
+                    $ranges[] = $value['range'];
+                }
+            }
+        }
+
+        return $ranges;
     }
 
     /**

--- a/app/Lsp/Features/Support/ReferenceFeature.php
+++ b/app/Lsp/Features/Support/ReferenceFeature.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Features\Support;
+
+use App\Lsp\Contracts\ReferenceProvider;
+use App\Lsp\Document;
+use App\Lsp\Project;
+
+/**
+ * Exposes a document mapper as a reference provider.
+ */
+abstract class ReferenceFeature implements ReferenceProvider
+{
+    /**
+     * Create a new reference feature instance.
+     */
+    public function __construct(
+        protected Project $project,
+    ) {}
+
+    /**
+     * Get the mapper that detects this feature's symbols.
+     */
+    abstract protected function mapper(): DocumentMapper;
+
+    /**
+     * Get the initialization option that enables this feature.
+     */
+    abstract protected function option(): string;
+
+    /**
+     * Get the symbol this provider owns at the given position, if any.
+     *
+     * @param  array<string, mixed>  $position
+     */
+    public function symbolAt(Document $document, array $position): ?string
+    {
+        return $this->enabled()
+            ? $this->mapper()->symbolAt($document, $position)
+            : null;
+    }
+
+    /**
+     * Get the ranges in the document that reference the given symbol.
+     *
+     * @return array<int, array<string, array<string, int>>>
+     */
+    public function ranges(Document $document, string $symbol): array
+    {
+        return $this->enabled()
+            ? $this->mapper()->rangesFor($document, $symbol)
+            : [];
+    }
+
+    /**
+     * Determine if the feature is enabled.
+     */
+    protected function enabled(): bool
+    {
+        return $this->project->boolean($this->option(), true);
+    }
+}

--- a/app/Lsp/Features/Translations/TranslationReferenceProvider.php
+++ b/app/Lsp/Features/Translations/TranslationReferenceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Features\Translations;
+
+use App\Lsp\Features\Support\DocumentMapper;
+use App\Lsp\Features\Support\ReferenceFeature;
+
+class TranslationReferenceProvider extends ReferenceFeature
+{
+    /**
+     * Get the mapper that detects translation symbols.
+     */
+    protected function mapper(): DocumentMapper
+    {
+        return new TranslationDocumentMapper($this->project);
+    }
+
+    /**
+     * Get the initialization option that enables translation references.
+     */
+    protected function option(): string
+    {
+        return 'translationReferences';
+    }
+}

--- a/app/Lsp/Features/Views/ViewReferenceProvider.php
+++ b/app/Lsp/Features/Views/ViewReferenceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Features\Views;
+
+use App\Lsp\Features\Support\DocumentMapper;
+use App\Lsp\Features\Support\ReferenceFeature;
+
+class ViewReferenceProvider extends ReferenceFeature
+{
+    /**
+     * Get the mapper that detects view symbols.
+     */
+    protected function mapper(): DocumentMapper
+    {
+        return new ViewDocumentMapper($this->project);
+    }
+
+    /**
+     * Get the initialization option that enables view references.
+     */
+    protected function option(): string
+    {
+        return 'viewReferences';
+    }
+}

--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -79,6 +79,7 @@ final class Initialize implements Method
                     'codeActionKinds' => ['quickfix'],
                 ],
                 'definitionProvider' => $project->boolean('definitionProvider', true),
+                'referencesProvider' => $project->boolean('referencesProvider', true),
                 'hoverProvider'      => true,
             ],
             'serverInfo' => [

--- a/app/Lsp/Methods/TextDocumentReferences.php
+++ b/app/Lsp/Methods/TextDocumentReferences.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Methods;
+
+use App\Lsp\Contracts\Method;
+use App\Lsp\Contracts\ReferenceProvider;
+use App\Lsp\Document;
+use App\Lsp\DocumentManager;
+use App\Lsp\FeatureRegistry;
+use App\Lsp\Project;
+use App\Lsp\Support\FileUri;
+use App\Lsp\Support\WorkspaceFiles;
+use App\Lsp\Transport\JsonRpcRequest;
+use App\Lsp\Transport\JsonRpcResponse;
+
+class TextDocumentReferences implements Method
+{
+    /**
+     * Instantiate a new class instance.
+     */
+    public function __construct(
+        protected DocumentManager $documents,
+        protected FeatureRegistry $features,
+        protected Project $project,
+    ) {}
+
+    /**
+     * Handle the textDocument/references request.
+     */
+    public function handle(JsonRpcRequest $request): JsonRpcResponse
+    {
+        $document = $this->documents->get(
+            (string) $request->get('textDocument.uri')
+        );
+
+        $position = $request->array('position');
+
+        if ($document === null || !$this->project->boolean('referencesProvider', true)) {
+            return JsonRpcResponse::result($request->id(), []);
+        }
+
+        [$provider, $symbol] = $this->symbolAt($document, $position);
+
+        if ($provider === null || $symbol === null) {
+            return JsonRpcResponse::result($request->id(), []);
+        }
+
+        return JsonRpcResponse::result(
+            $request->id(),
+            $this->locations($provider, $symbol, $request),
+        );
+    }
+
+    /**
+     * Resolve the provider and symbol under the cursor.
+     *
+     * @param  array<string, mixed>  $position
+     * @return array{0: ReferenceProvider|null, 1: string|null}
+     */
+    protected function symbolAt(Document $document, array $position): array
+    {
+        foreach ($this->features->references() as $provider) {
+            $symbol = $provider->symbolAt($document, $position);
+
+            if ($symbol !== null && $symbol !== '') {
+                return [$provider, $symbol];
+            }
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * Collect every workspace location referencing the symbol.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function locations(
+        ReferenceProvider $provider,
+        string $symbol,
+        JsonRpcRequest $request,
+    ): array {
+        $locations = [];
+
+        foreach ((new WorkspaceFiles($this->project))->containing($symbol) as $path => $contents) {
+            $uri = (string) FileUri::fromPath($path);
+
+            // Prefer the editor's copy so unsaved edits are not searched stale.
+            $scanned = $this->documents->get($uri) ?? new Document($uri, $contents);
+
+            foreach ($provider->ranges($scanned, $symbol) as $range) {
+                $locations[] = ['uri' => $uri, 'range' => $range];
+            }
+
+            $request->cancelIfRequested();
+        }
+
+        return $locations;
+    }
+}

--- a/app/Lsp/Server.php
+++ b/app/Lsp/Server.php
@@ -31,6 +31,7 @@ use App\Lsp\Methods\TextDocumentCompletion;
 use App\Lsp\Methods\TextDocumentDefinition;
 use App\Lsp\Methods\TextDocumentDocumentLink;
 use App\Lsp\Methods\TextDocumentHover;
+use App\Lsp\Methods\TextDocumentReferences;
 use App\Lsp\Transport\AmpStdioTransport;
 use App\Lsp\Transport\JsonRpcRequest;
 use App\Lsp\Transport\JsonRpcResponse;
@@ -58,6 +59,7 @@ final class Server
         'textDocument/definition'   => TextDocumentDefinition::class,
         'textDocument/documentLink' => TextDocumentDocumentLink::class,
         'textDocument/hover'        => TextDocumentHover::class,
+        'textDocument/references'   => TextDocumentReferences::class,
     ];
 
     /**

--- a/app/Lsp/Support/WorkspaceFiles.php
+++ b/app/Lsp/Support/WorkspaceFiles.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lsp\Support;
+
+use App\Lsp\Project;
+use FilesystemIterator;
+use Generator;
+use RecursiveCallbackFilterIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Walks the PHP and Blade files of the workspace.
+ *
+ * Reference lookups always know the exact string they are looking for, so the
+ * walk yields only files whose contents contain it. Parsing is then limited to
+ * the handful of files that can possibly match, which keeps a workspace-wide
+ * search off the parser for almost every file in the project.
+ */
+class WorkspaceFiles
+{
+    /**
+     * Directory names that never hold project source.
+     */
+    protected const SKIPPED_DIRECTORIES = [
+        '.git',
+        '.idea',
+        '.vscode',
+        'bootstrap/cache',
+        'node_modules',
+        'public/build',
+        'storage',
+        'vendor',
+    ];
+
+    /**
+     * The largest file worth reading, in bytes.
+     */
+    protected const MAX_FILE_SIZE = 2097152;
+
+    /**
+     * Create a new workspace file walker instance.
+     */
+    public function __construct(
+        protected Project $project,
+    ) {}
+
+    /**
+     * Get workspace files whose contents contain the given needle.
+     *
+     * @return Generator<string, string>
+     */
+    public function containing(string $needle): Generator
+    {
+        if ($needle === '') {
+            return;
+        }
+
+        foreach ($this->all() as $path) {
+            $contents = @file_get_contents($path);
+
+            if ($contents === false || !str_contains($contents, $needle)) {
+                continue;
+            }
+
+            yield $path => $contents;
+        }
+    }
+
+    /**
+     * Get every PHP file in the workspace.
+     *
+     * @return Generator<int, string>
+     */
+    public function all(): Generator
+    {
+        $basePath = $this->project->path();
+
+        if (!is_dir($basePath)) {
+            return;
+        }
+
+        $directories = new RecursiveDirectoryIterator(
+            $basePath,
+            FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO,
+        );
+
+        $filtered = new RecursiveCallbackFilterIterator(
+            $directories,
+            fn (SplFileInfo $file): bool => $this->shouldVisit($file, $basePath),
+        );
+
+        foreach (new RecursiveIteratorIterator($filtered) as $file) {
+            /** @var SplFileInfo $file */
+            if ($file->isFile()) {
+                yield $file->getPathname();
+            }
+        }
+    }
+
+    /**
+     * Determine if the walk should descend into or read the given entry.
+     */
+    protected function shouldVisit(SplFileInfo $file, string $basePath): bool
+    {
+        if ($file->isDir()) {
+            return !$this->isSkipped($file->getPathname(), $basePath);
+        }
+
+        return $file->getExtension() === 'php'
+            && $file->getSize() <= self::MAX_FILE_SIZE;
+    }
+
+    /**
+     * Determine if the directory is excluded from the walk.
+     */
+    protected function isSkipped(string $path, string $basePath): bool
+    {
+        $relative = trim(str_replace('\\', '/', substr($path, strlen($basePath))), '/');
+
+        foreach (self::SKIPPED_DIRECTORIES as $skipped) {
+            if ($relative === $skipped || str_starts_with($relative, $skipped . '/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/ReferencesTest.php
+++ b/tests/Unit/ReferencesTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use App\Lsp\DocumentManager;
+use App\Lsp\FeatureRegistry;
+use App\Lsp\Methods\TextDocumentReferences;
+use App\Lsp\Project;
+use App\Lsp\ProjectIndex;
+use App\Lsp\ScriptRunner;
+use App\Lsp\Support\FileUri;
+use App\Lsp\Support\WorkspaceFiles;
+use App\Lsp\Transport\JsonRpcRequest;
+use Illuminate\Container\Container;
+
+/**
+ * Build a throwaway project on disk from a map of relative paths to contents.
+ */
+function workspace(array $files): string
+{
+    $root = sys_get_temp_dir() . '/lsp-references-' . bin2hex(random_bytes(6));
+
+    foreach ($files as $path => $contents) {
+        $target = $root . '/' . $path;
+
+        if (!is_dir(dirname($target))) {
+            mkdir(dirname($target), 0777, true);
+        }
+
+        file_put_contents($target, $contents);
+    }
+
+    return $root;
+}
+
+function removeWorkspace(string $root): void
+{
+    $paths = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($paths as $path) {
+        $path->isDir() ? rmdir($path->getPathname()) : unlink($path->getPathname());
+    }
+
+    rmdir($root);
+}
+
+function projectAt(string $root, array $options = []): Project
+{
+    $uri = FileUri::fromPath($root);
+
+    return new Project($uri, $options, new ProjectIndex(new Container), new ScriptRunner($root, ['php']));
+}
+
+/**
+ * Run a textDocument/references request against the given workspace.
+ */
+function references(string $root, string $uri, array $position, array $options = []): array
+{
+    $container = new Container;
+    $project = projectAt($root, $options);
+
+    $container->instance(Project::class, $project);
+
+    $documents = new DocumentManager;
+    $documents->open($uri, (string) file_get_contents(FileUri::of($uri)->path()));
+
+    $method = new TextDocumentReferences($documents, new FeatureRegistry($container), $project);
+
+    $response = $method->handle(new JsonRpcRequest(1, 'textDocument/references', [
+        'textDocument' => ['uri' => $uri],
+        'position'     => $position,
+        'context'      => ['includeDeclaration' => true],
+    ]));
+
+    return $response->toArray()['result'];
+}
+
+test('finds every workspace reference to a route name', function () {
+    $root = workspace([
+        'artisan'                            => '',
+        'routes/web.php'                     => "<?php\nRoute::get('/users', [UserController::class, 'index'])->name('users.index');\n",
+        'app/Http/Controllers/Home.php'      => "<?php\nfunction go() { return redirect()->route('users.index'); }\n",
+        'resources/views/nav.blade.php'      => "<a href=\"{{ route('users.index') }}\">Users</a>\n",
+        'app/Http/Controllers/Other.php'     => "<?php\nfunction go() { return route('users.create'); }\n",
+        'vendor/acme/pkg/src/Ignored.php'    => "<?php\nroute('users.index');\n",
+    ]);
+
+    $uri = (string) FileUri::fromPath($root . '/app/Http/Controllers/Home.php');
+
+    $found = references($root, $uri, ['line' => 1, 'character' => 42]);
+
+    $uris = array_map(fn (array $location): string => $location['uri'], $found);
+
+    // The ->name() call in routes/web.php declares the route rather than
+    // referencing it, so it is not a reference.
+    expect($found)->toHaveCount(2)
+        ->and($uris)->toContain($uri)
+        ->and($uris)->toContain((string) FileUri::fromPath($root . '/resources/views/nav.blade.php'))
+        ->and($uris)->not->toContain((string) FileUri::fromPath($root . '/vendor/acme/pkg/src/Ignored.php'));
+
+    removeWorkspace($root);
+});
+
+test('returns nothing when the cursor is not on a known symbol', function () {
+    $root = workspace([
+        'artisan'                       => '',
+        'app/Http/Controllers/Home.php' => "<?php\nfunction go() { return route('users.index'); }\n",
+    ]);
+
+    $uri = (string) FileUri::fromPath($root . '/app/Http/Controllers/Home.php');
+
+    expect(references($root, $uri, ['line' => 1, 'character' => 2]))->toBe([]);
+
+    removeWorkspace($root);
+});
+
+test('honours the referencesProvider option', function () {
+    $root = workspace([
+        'artisan'                       => '',
+        'app/Http/Controllers/Home.php' => "<?php\nfunction go() { return route('users.index'); }\n",
+        'routes/web.php'                => "<?php\nRoute::get('/u', 'x')->name('users.index');\n",
+    ]);
+
+    $uri = (string) FileUri::fromPath($root . '/app/Http/Controllers/Home.php');
+
+    expect(references($root, $uri, ['line' => 1, 'character' => 35]))->not->toBeEmpty()
+        ->and(references($root, $uri, ['line' => 1, 'character' => 35], ['referencesProvider' => false]))
+        ->toBe([]);
+
+    removeWorkspace($root);
+});
+
+test('finds view references across php and blade files', function () {
+    $root = workspace([
+        'artisan'                          => '',
+        'app/Http/Controllers/Home.php'    => "<?php\nfunction show() { return view('pages.home'); }\n",
+        'resources/views/layout.blade.php' => "@include('pages.home')\n",
+        'resources/views/other.blade.php'  => "@include('pages.about')\n",
+    ]);
+
+    $uri = (string) FileUri::fromPath($root . '/app/Http/Controllers/Home.php');
+
+    $found = references($root, $uri, ['line' => 1, 'character' => 36]);
+
+    expect($found)->toHaveCount(2);
+
+    removeWorkspace($root);
+});
+
+test('the workspace walker skips vendor and non-php files', function () {
+    $root = workspace([
+        'artisan'                         => '',
+        'app/Example.php'                 => '<?php // needle',
+        'resources/views/a.blade.php'     => '{{ "needle" }}',
+        'resources/js/app.js'             => '// needle',
+        'vendor/acme/src/Vendor.php'      => '<?php // needle',
+        'node_modules/pkg/index.php'      => '<?php // needle',
+        'storage/framework/views/abc.php' => '<?php // needle',
+    ]);
+
+    $paths = [];
+
+    foreach ((new WorkspaceFiles(projectAt($root)))->containing('needle') as $path => $contents) {
+        $paths[] = str_replace($root . '/', '', $path);
+    }
+
+    sort($paths);
+
+    expect($paths)->toBe(['app/Example.php', 'resources/views/a.blade.php']);
+
+    removeWorkspace($root);
+});
+
+test('the workspace walker reads the editor copy of an open document', function () {
+    $root = workspace([
+        'artisan'                       => '',
+        'app/Http/Controllers/Home.php' => "<?php\nfunction go() { return route('users.index'); }\n",
+        'routes/web.php'                => "<?php\nRoute::get('/u', 'x')->name('users.index');\n",
+    ]);
+
+    $uri = (string) FileUri::fromPath($root . '/app/Http/Controllers/Home.php');
+    $container = new Container;
+    $project = projectAt($root);
+
+    $container->instance(Project::class, $project);
+
+    $documents = new DocumentManager;
+
+    // The editor holds a second, unsaved reference the file on disk lacks.
+    $documents->open($uri, "<?php\nfunction go() { return route('users.index'); }\nfunction b() { return route('users.index'); }\n");
+
+    $method = new TextDocumentReferences($documents, new FeatureRegistry($container), $project);
+
+    $found = $method->handle(new JsonRpcRequest(1, 'textDocument/references', [
+        'textDocument' => ['uri' => $uri],
+        'position'     => ['line' => 1, 'character' => 35],
+    ]))->toArray()['result'];
+
+    $inDocument = array_filter($found, fn (array $location): bool => $location['uri'] === $uri);
+
+    expect($inDocument)->toHaveCount(2);
+
+    removeWorkspace($root);
+});


### PR DESCRIPTION
Addresses #83.

Adds `textDocument/references` for Laravel symbols, which is the piece Neovim needs for the reference counts in that screenshot. Clients that render counts inline (`lsp-lens.nvim`, `nvim-lsp-endhints`, and friends) get them by calling `textDocument/references` and counting the result, so this is what makes them light up.

Put the cursor inside a route name, view name, config key, or translation key and the server returns every other place in the workspace using that same name, across both PHP and Blade.

## How the search stays cheap

A reference lookup always knows the exact string it is hunting for, which is the whole trick. `WorkspaceFiles::containing()` walks the project and yields only files whose contents contain that literal string, so the parser runs on the handful of files that can possibly match rather than every PHP file in the project. Looking for `users.index` in a large app typically parses a few files, not a few thousand.

`vendor`, `node_modules`, `storage`, `bootstrap/cache`, `public/build`, and the editor and VCS directories are never walked. Files over 2 MB are skipped. The walk is a generator and the handler calls `cancelIfRequested()` between files, so an abandoned lookup stops early rather than finishing the project.

## How a reference is decided

No new detection rules. `DocumentMapper` already declares the patterns that drive links, hovers, and diagnostics for each feature, so it can answer both questions a reference lookup asks:

- `symbolAt()` gives the symbol under the cursor
- `rangesFor()` gives every range in a document matching a symbol

Both go through `stringValues()`, so an argument holding an array of names (`@each`, `@include` with a list) matches element by element rather than all-or-nothing.

`ReferenceFeature` exposes a mapper as a `ReferenceProvider`, and the four providers are three lines each. Every provider is gated by its own option (`routeReferences`, `viewReferences`, `configReferences`, `translationReferences`) alongside the top level `referencesProvider`, matching how the other capabilities are configured.

Open documents are read from the `DocumentManager` rather than from disk, so unsaved edits are searched rather than a stale file.

## Scope

**These are usages, not declarations.** Asking for references to `users.index` from `route('users.index')` finds the other calls that build that URL, not the `->name('users.index')` that declares it. Declaration patterns are not part of the existing mappers and adding them would change what links, hovers, and diagnostics match, which felt like the wrong thing to fold into this PR. Happy to add them if you want `context.includeDeclaration` honoured properly.

A `codeLens` provider that renders the count above a declaration is the natural next step and would sit directly on top of `ReferenceProvider`. It needs the declaration patterns above first, and a decision about which declarations get a lens, so I have left it out rather than guess. Say the word and I will add it here.

## Tests

`tests/Unit/ReferencesTest.php` builds throwaway projects on disk and drives the real request handler: route references across PHP and Blade, view references, a cursor sitting on nothing, the disabling option in both states, the editor's unsaved copy of an open document, and the walker skipping `vendor`, `node_modules`, `storage`, and non-PHP files.

Note: the `ParserTest` and `DetectTest` failures on this branch are present on `main` too. They read fixtures from `tests/../snippets` while the fixtures live at the repo root. Not touched here.
