### PR TITLE
Discover Eloquent models from the application's autoload roots

### DIFF
--- a/app/Lsp/Data/Templates/models.php
+++ b/app/Lsp/Data/Templates/models.php
@@ -65,13 +65,49 @@ $models = new class($factory)
         $this->output = new BufferedOutput;
     }
 
+    /**
+     * Get the files that may declare the application's models.
+     *
+     * Models are not required to live in app/Models, so each namespace the
+     * application autoloads is searched for a Models directory. Only the
+     * production autoload roots are used, since the dev roots cover tests
+     * that are not safe to include.
+     */
+    protected function modelFiles()
+    {
+        $composer = base_path('composer.json');
+        $roots = collect();
+
+        if (is_file($composer)) {
+            $config = json_decode((string) file_get_contents($composer), true);
+
+            $roots = collect($config['autoload']['psr-4'] ?? [])
+                ->flatten()
+                ->map(fn ($path) => base_path(trim((string) $path, '/')));
+        }
+
+        return $roots
+            ->push(base_path('app'))
+            ->map(fn ($path) => realpath($path) ?: null)
+            ->filter(fn ($path) => $path !== null && File::isDirectory($path))
+            ->unique()
+            ->flatMap(fn ($root) => File::allFiles($root))
+            ->filter(fn (SplFileInfo $file) => $file->getExtension() === 'php')
+            ->map(fn (SplFileInfo $file) => $file->getRealPath() ?: $file->getPathname())
+            ->filter(fn ($path) => str_contains(str_replace('\\', '/', $path), '/Models/'))
+            ->unique()
+            ->values();
+    }
+
     public function all()
     {
-        if (File::isDirectory(base_path('app/Models'))) {
-            collect(File::allFiles(base_path('app/Models')))
-                ->filter(fn (SplFileInfo $file) => $file->getExtension() === 'php')
-                ->each(fn ($file) => include_once ($file));
-        }
+        $this->modelFiles()->each(function ($file) {
+            try {
+                include_once $file;
+            } catch (Throwable $e) {
+                // A file that refuses to load should not hide every other model.
+            }
+        });
 
         return collect(get_declared_classes())
             ->filter(fn ($class) => is_subclass_of($class, Model::class))

--- a/app/Lsp/Data/Templates/models.php
+++ b/app/Lsp/Data/Templates/models.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use phpDocumentor\Reflection\DocBlockFactory;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 if (class_exists('\phpDocumentor\Reflection\DocBlockFactory')) {
@@ -71,7 +72,8 @@ $models = new class($factory)
      * Models are not required to live in app/Models, so each namespace the
      * application autoloads is searched for a Models directory. Only the
      * production autoload roots are used, since the dev roots cover tests
-     * that are not safe to include.
+     * that are not safe to include. Directories are matched first so that
+     * files outside a Models directory are never enumerated.
      */
     protected function modelFiles()
     {
@@ -91,10 +93,17 @@ $models = new class($factory)
             ->map(fn ($path) => realpath($path) ?: null)
             ->filter(fn ($path) => $path !== null && File::isDirectory($path))
             ->unique()
-            ->flatMap(fn ($root) => File::allFiles($root))
-            ->filter(fn (SplFileInfo $file) => $file->getExtension() === 'php')
-            ->map(fn (SplFileInfo $file) => $file->getRealPath() ?: $file->getPathname())
-            ->filter(fn ($path) => str_contains(str_replace('\\', '/', $path), '/Models/'))
+            ->flatMap(fn ($root) => iterator_to_array(
+                Finder::create()->directories()->name('Models')->in($root)->ignoreUnreadableDirs(),
+                false
+            ))
+            ->map(fn (SplFileInfo $directory) => $directory->getPathname())
+            ->unique()
+            ->flatMap(fn ($directory) => iterator_to_array(
+                Finder::create()->files()->name('*.php')->in($directory)->ignoreUnreadableDirs(),
+                false
+            ))
+            ->map(fn (SplFileInfo $file) => $file->getPathname())
             ->unique()
             ->values();
     }


### PR DESCRIPTION
Fixes #95.

`models.php` only includes files from `app/Models`, so if the models live anywhere else you get whatever a bare boot happened to autoload. on a laravel 12 app with the models moved to `app/Domain/Sales/Models`:

| layout | before | after |
|---|---|---|
| models in `app/Domain/Sales/Models`, no `app/Models` | 0 | 29 |
| default `app/Models` plus one model outside it | 28 | 29 |

this pulls the psr-4 roots out of `composer.json` and picks up any `Models` directory under them.

i tried `vendor/composer/autoload_psr4.php` first and it doesnt work, it merges `autoload-dev` so `Tests\` comes with it and including those files throws `INVALID PEST COMMAND  Please run [./vendor/bin/pest] instead`. `composer.json` leaves the dev roots out.

filtering on `/Models/` still wasnt enough, one of my projects has `tests/Unit/Models` and hit the same thing, hence production roots only. the `include_once` is wrapped so one file that wont load cant take the rest with it.

old vs new across 8 real apps, same model counts everywhere. timing is a wash, whichever one runs second is faster.
