### PR TITLE
Skip diagnostics for interpolated string arguments

### DIFF
--- a/app/Contexts/StringValue.php
+++ b/app/Contexts/StringValue.php
@@ -6,6 +6,8 @@ class StringValue extends AbstractContext
 {
     public ?string $value = null;
 
+    public bool $interpolated = false;
+
     protected bool $hasChildren = false;
 
     public function type(): string
@@ -15,8 +17,9 @@ class StringValue extends AbstractContext
 
     public function castToArray(): array
     {
-        return [
-            'value' => $this->value,
-        ];
+        return array_merge(
+            ['value' => $this->value],
+            $this->interpolated ? ['interpolated' => true] : [],
+        );
     }
 }

--- a/app/Lsp/Detection/DetectedArgument.php
+++ b/app/Lsp/Detection/DetectedArgument.php
@@ -76,6 +76,14 @@ class DetectedArgument
     }
 
     /**
+     * Determine if the argument is an interpolated string.
+     */
+    public function isInterpolated(): bool
+    {
+        return ($this->param['interpolated'] ?? false) === true;
+    }
+
+    /**
      * Get the detected parameter value as a string.
      */
     public function stringValue(): ?string

--- a/app/Lsp/Detection/DetectedArgument.php
+++ b/app/Lsp/Detection/DetectedArgument.php
@@ -102,8 +102,9 @@ class DetectedArgument
     {
         if ($this->param['type'] === 'string') {
             return [[
-                'value' => $this->param['value'],
-                'range' => $this->range(),
+                'value'        => $this->param['value'],
+                'range'        => $this->range(),
+                'interpolated' => $this->isInterpolated(),
             ]];
         }
 
@@ -117,12 +118,26 @@ class DetectedArgument
             }
 
             $values[] = [
-                'value' => $value['value'],
-                'range' => $this->rangeForValue($value),
+                'value'        => $value['value'],
+                'range'        => $this->rangeForValue($value),
+                'interpolated' => ($value['interpolated'] ?? false) === true,
             ];
         }
 
         return $values;
+    }
+
+    /**
+     * Get the detected string values, excluding interpolated ones.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function literalStringValues(): array
+    {
+        return array_values(array_filter(
+            $this->stringValues(),
+            fn (array $value): bool => $value['interpolated'] !== true,
+        ));
     }
 
     /**

--- a/app/Lsp/Features/Auth/AuthDocumentMapper.php
+++ b/app/Lsp/Features/Auth/AuthDocumentMapper.php
@@ -10,8 +10,8 @@ use App\Lsp\Detection\DetectedArguments;
 use App\Lsp\Detection\Pattern;
 use App\Lsp\Document;
 use App\Lsp\Features\Support\DocumentMapper;
-use App\Lsp\Support\Position;
 use App\Lsp\Project;
+use App\Lsp\Support\Position;
 use Illuminate\Support\Collection;
 
 class AuthDocumentMapper extends DocumentMapper
@@ -103,7 +103,7 @@ class AuthDocumentMapper extends DocumentMapper
      */
     protected function toDiagnostics(DetectedArgument $argument): array
     {
-        return collect($argument->stringValues())
+        return collect($argument->literalStringValues())
             ->flatMap(fn (array $value): array => $this->diagnosticFrom($argument, $value['value'], $value['range']))
             ->values()
             ->all();

--- a/app/Lsp/Features/Middleware/MiddlewareDocumentMapper.php
+++ b/app/Lsp/Features/Middleware/MiddlewareDocumentMapper.php
@@ -10,8 +10,8 @@ use App\Lsp\Detection\DetectedArguments;
 use App\Lsp\Detection\Pattern;
 use App\Lsp\Document;
 use App\Lsp\Features\Support\DocumentMapper;
-use App\Lsp\Support\Position;
 use App\Lsp\Project;
+use App\Lsp\Support\Position;
 use Illuminate\Support\Collection;
 
 class MiddlewareDocumentMapper extends DocumentMapper
@@ -118,7 +118,7 @@ class MiddlewareDocumentMapper extends DocumentMapper
      */
     protected function toDiagnostics(DetectedArgument $argument): array
     {
-        return collect($argument->stringValues())
+        return collect($argument->literalStringValues())
             ->reject(fn (array $value): bool => $this->find($this->name($value['value'])) !== null)
             ->map(fn (array $value): array => [
                 'range'    => $value['range'],

--- a/app/Lsp/Features/Support/DocumentMapper.php
+++ b/app/Lsp/Features/Support/DocumentMapper.php
@@ -132,6 +132,7 @@ abstract class DocumentMapper
     public function diagnostics(Document $document): array
     {
         return $this->arguments($document)
+            ->reject(fn (DetectedArgument $argument): bool => $argument->isInterpolated())
             ->flatMap(fn (DetectedArgument $argument): array => $this->toDiagnostics($argument))
             ->values()
             ->all();

--- a/app/Parsers/StringLiteralParser.php
+++ b/app/Parsers/StringLiteralParser.php
@@ -5,6 +5,7 @@ namespace App\Parsers;
 use App\Contexts\AbstractContext;
 use App\Contexts\StringValue;
 use App\Parser\Settings;
+use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Microsoft\PhpParser\PositionUtilities;
 
@@ -18,6 +19,7 @@ class StringLiteralParser extends AbstractParser
     public function parse(StringLiteral $node)
     {
         $this->context->value = $node->getStringContentsText();
+        $this->context->interpolated = $this->isInterpolated($node);
 
         if (Settings::$capturePosition) {
             $range = PositionUtilities::getRangeFromPosition(
@@ -34,6 +36,29 @@ class StringLiteralParser extends AbstractParser
         }
 
         return $this->context;
+    }
+
+    /**
+     * Determine if the string contains an interpolated expression.
+     *
+     * The contents are read straight from the source, so an interpolated
+     * string yields the expression verbatim rather than its value. Only
+     * interpolation produces child nodes; escaped dollars, single quoted
+     * strings and nowdocs are plain tokens.
+     */
+    protected function isInterpolated(StringLiteral $node): bool
+    {
+        if (!is_array($node->children)) {
+            return false;
+        }
+
+        foreach ($node->children as $child) {
+            if ($child instanceof Node) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function initNewContext(): ?AbstractContext

--- a/app/Parsers/StringLiteralParser.php
+++ b/app/Parsers/StringLiteralParser.php
@@ -8,6 +8,7 @@ use App\Parser\Settings;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\StringLiteral;
 use Microsoft\PhpParser\PositionUtilities;
+use Microsoft\PhpParser\TokenKind;
 
 class StringLiteralParser extends AbstractParser
 {
@@ -18,13 +19,15 @@ class StringLiteralParser extends AbstractParser
 
     public function parse(StringLiteral $node)
     {
-        $this->context->value = $node->getStringContentsText();
+        $contents = $this->contents($node);
+
+        $this->context->value = $contents;
         $this->context->interpolated = $this->isInterpolated($node);
 
         if (Settings::$capturePosition) {
             $range = PositionUtilities::getRangeFromPosition(
                 $node->getStartPosition(),
-                mb_strlen($node->getStringContentsText()),
+                mb_strlen($contents),
                 $node->getRoot()->getFullText(),
             );
 
@@ -36,6 +39,23 @@ class StringLiteralParser extends AbstractParser
         }
 
         return $this->context;
+    }
+
+    /**
+     * Get the contents of the string.
+     *
+     * A heredoc or nowdoc body ends with the newline that precedes its
+     * closing identifier, which PHP does not include in the value.
+     */
+    protected function contents(StringLiteral $node): string
+    {
+        $contents = $node->getStringContentsText();
+
+        if (($node->startQuote->kind ?? null) !== TokenKind::HeredocStart) {
+            return $contents;
+        }
+
+        return preg_replace('/\r?\n$/', '', $contents);
     }
 
     /**

--- a/tests/Unit/InterpolatedStringTest.php
+++ b/tests/Unit/InterpolatedStringTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Lsp\Detection\DetectedArgument;
+use App\Parser\DetectWalker;
+
+function firstStringParam(string $code): ?array
+{
+    $context = (new DetectWalker("<?php\n" . $code))->walk();
+
+    $find = function (array $node) use (&$find): ?array {
+        if (($node['type'] ?? null) === 'string') {
+            return $node;
+        }
+
+        foreach ($node as $value) {
+            if (is_array($value)) {
+                $found = is_string(key($value)) ? $find($value) : null;
+
+                if ($found === null) {
+                    foreach ($value as $item) {
+                        if (is_array($item) && ($found = $find($item)) !== null) {
+                            break;
+                        }
+                    }
+                }
+
+                if ($found !== null) {
+                    return $found;
+                }
+            }
+        }
+
+        return null;
+    };
+
+    return $find(json_decode($context->toJson(), true));
+}
+
+test('plain strings are not marked as interpolated', function (string $code) {
+    $param = firstStringParam($code);
+
+    expect($param)->not->toBeNull();
+    expect($param['interpolated'] ?? false)->toBeFalse();
+})->with([
+    "config('auth.passwords.users.table');",
+    'config("auth.passwords.users.table");',
+    "config('auth.passwords.\$broker.table');",
+    'config("auth.passwords.\\$broker.table");',
+    "config(<<<'EOT'\nauth.passwords.users.table\nEOT);",
+]);
+
+test('interpolated strings are marked as interpolated', function (string $code) {
+    $param = firstStringParam($code);
+
+    expect($param)->not->toBeNull();
+    expect($param['interpolated'] ?? false)->toBeTrue();
+})->with([
+    'config("auth.passwords.$broker.table");',
+    'config("auth.passwords.{$broker}.table");',
+    'config("auth.passwords.{$this->broker()}.table");',
+    'config("auth.passwords.{$model->broker()}.table");',
+    'config("auth.passwords.$config[broker].table");',
+    'config("auth.passwords.$model->broker.table");',
+    "config(<<<EOT\nauth.passwords.\$broker.table\nEOT);",
+]);
+
+test('a detected argument reports whether its string is interpolated', function () {
+    $plain = new DetectedArgument([], 0, ['type' => 'string', 'value' => 'a.b']);
+    $interpolated = new DetectedArgument([], 0, ['type' => 'string', 'value' => 'a.{$b}', 'interpolated' => true]);
+
+    expect($plain->isInterpolated())->toBeFalse();
+    expect($interpolated->isInterpolated())->toBeTrue();
+});

--- a/tests/Unit/InterpolatedStringTest.php
+++ b/tests/Unit/InterpolatedStringTest.php
@@ -71,3 +71,42 @@ test('a detected argument reports whether its string is interpolated', function 
     expect($plain->isInterpolated())->toBeFalse();
     expect($interpolated->isInterpolated())->toBeTrue();
 });
+
+function stringChild(string $value, bool $interpolated = false): array
+{
+    return array_merge([
+        'type'  => 'string',
+        'value' => $value,
+        'start' => ['line' => 0, 'column' => 0],
+        'end'   => ['line' => 0, 'column' => strlen($value)],
+    ], $interpolated ? ['interpolated' => true] : []);
+}
+
+test('a heredoc or nowdoc value drops the newline before its closing identifier', function (string $code, string $expected) {
+    $param = firstStringParam($code);
+
+    expect($param)->not->toBeNull();
+    expect($param['value'])->toBe($expected);
+})->with([
+    ["config(<<<'EOT'\nauth.passwords.users.table\nEOT);", 'auth.passwords.users.table'],
+    ["config(<<<EOT\nauth.passwords.users.table\nEOT);", 'auth.passwords.users.table'],
+    ["config(<<<'EOT'\nline1\nline2\nEOT);", "line1\nline2"],
+    ["config('auth.passwords.users.table');", 'auth.passwords.users.table'],
+]);
+
+test('literal string values exclude interpolated members of an array argument', function () {
+    $argument = new DetectedArgument([], 0, [
+        'type'     => 'array',
+        'children' => [
+            ['value' => stringChild('auth')],
+            ['value' => stringChild('role:{$g}', true)],
+            ['value' => stringChild('verified')],
+        ],
+    ]);
+
+    expect(array_column($argument->stringValues(), 'value'))
+        ->toBe(['auth', 'role:{$g}', 'verified']);
+
+    expect(array_column($argument->literalStringValues(), 'value'))
+        ->toBe(['auth', 'verified']);
+});


### PR DESCRIPTION
Fixes #98.

diagnostics take the key from `getStringContentsText()`, which hands back the raw source, so an interpolated string gets validated as if the braces were part of the key. its not config only, same shape in env, route, view, asset and middleware.

interpolation is visible in the parse tree. an interpolated `StringLiteral` has expression nodes among its children, a plain one is all tokens. `StringLiteralParser` records that and `DocumentMapper::diagnostics()` skips those arguments. links, hovers and completions are untouched.

checked against a running server:

| written as | before | after |
|---|---|---|
| `config("a.{$this->b()}.c")` | warns | silent |
| `config("a.{$b}.c")` | warns | silent |
| `config("a.$b.c")` | warns | silent |
| `view("pages.{$s}")` / `env("APP_{$n}")` / `route("admin.{$n}")` / `asset("build/{$f}.css")` | warns | silent |
| `middleware(['auth', "role:{$g}"])` | warns | silent |
| `config('a.$b.c')` single quoted | warns | warns |
| `config("a.\$b.c")` escaped | warns | warns |
| nowdoc containing `$b` | warns | warns |
| `config('typo.key')`, `middleware(['auth', 'no-such-mw'])` | warns | warns |

the bottom four are why this reads the parse tree instead of looking for a `$` in the value. those are literal keys and a typo in one should still get caught.

two things came out of testing it. array arguments needed handling separately, since the flag sits on each member rather than the argument. and a heredoc or nowdoc body keeps the newline before its closing identifier, which php does not include in the value, so a valid key written that way was also reported missing. both are fixed here.

the flag is only serialized when a string is interpolated, so the rest of the detect output is unchanged.
