### PR TITLE
Resolve escape sequences when reading string values

### DIFF
--- a/app/Parsers/StringLiteralParser.php
+++ b/app/Parsers/StringLiteralParser.php
@@ -50,12 +50,76 @@ class StringLiteralParser extends AbstractParser
     protected function contents(StringLiteral $node): string
     {
         $contents = $node->getStringContentsText();
+        $kind = $this->kind($node);
 
-        if (($node->startQuote->kind ?? null) !== TokenKind::HeredocStart) {
-            return $contents;
+        if ($kind === 'heredoc' || $kind === 'nowdoc') {
+            $contents = preg_replace('/\r?\n$/', '', $contents);
         }
 
-        return preg_replace('/\r?\n$/', '', $contents);
+        return match ($kind) {
+            'nowdoc'  => $contents,
+            'single'  => strtr($contents, ['\\\\' => '\\', "\\'" => "'"]),
+            'heredoc' => $this->unescape($contents, false),
+            default   => $this->unescape($contents, true),
+        };
+    }
+
+    /**
+     * Get the kind of string literal the node holds.
+     */
+    protected function kind(StringLiteral $node): string
+    {
+        if (($node->startQuote->kind ?? null) !== TokenKind::HeredocStart) {
+            return ($node->getRoot()->getFullText()[$node->getStartPosition()] ?? '"') === "'"
+                ? 'single'
+                : 'double';
+        }
+
+        $start = substr($node->getRoot()->getFullText(), $node->getStartPosition(), 32);
+
+        return preg_match('/^<<<[ \t]*\'/', $start) === 1 ? 'nowdoc' : 'heredoc';
+    }
+
+    /**
+     * Resolve the escape sequences PHP evaluates in a double quoted string.
+     *
+     * A heredoc uses the same rules except that a quote is never escaped,
+     * so a backslash before one is kept.
+     */
+    protected function unescape(string $contents, bool $escapesQuote): string
+    {
+        return preg_replace_callback(
+            '/\\\\(u\{[0-9A-Fa-f]+\}|x[0-9A-Fa-f]{1,2}|[0-7]{1,3}|.)/s',
+            function (array $matches) use ($escapesQuote): string {
+                $sequence = $matches[1];
+
+                if (str_starts_with($sequence, 'u{')) {
+                    return mb_chr((int) hexdec(substr($sequence, 2, -1)), 'UTF-8') ?: $matches[0];
+                }
+
+                if ($sequence[0] === 'x' && strlen($sequence) > 1) {
+                    return chr((int) hexdec(substr($sequence, 1)));
+                }
+
+                if (preg_match('/^[0-7]{1,3}$/', $sequence) === 1) {
+                    return chr((int) octdec($sequence) % 256);
+                }
+
+                return match (true) {
+                    $sequence === 'n'                  => "\n",
+                    $sequence === 'r'                  => "\r",
+                    $sequence === 't'                  => "\t",
+                    $sequence === 'v'                  => "\v",
+                    $sequence === 'e'                  => "\e",
+                    $sequence === 'f'                  => "\f",
+                    $sequence === '\\'                 => '\\',
+                    $sequence === '$'                  => '$',
+                    $sequence === '"' && $escapesQuote => '"',
+                    default                            => $matches[0],
+                };
+            },
+            $contents
+        );
     }
 
     /**

--- a/tests/Unit/StringEscapeTest.php
+++ b/tests/Unit/StringEscapeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Parser\DetectWalker;
+
+function parsedStringValue(string $literal): ?string
+{
+    $context = (new DetectWalker("<?php\nf(" . $literal . ');'))->walk();
+
+    $stack = [json_decode($context->toJson(), true)];
+
+    while ($stack !== []) {
+        $node = array_pop($stack);
+
+        if (!is_array($node)) {
+            continue;
+        }
+
+        if (($node['type'] ?? null) === 'string') {
+            return $node['value'];
+        }
+
+        foreach ($node as $child) {
+            if (is_array($child)) {
+                $stack[] = $child;
+            }
+        }
+    }
+
+    return null;
+}
+
+test('a parsed string value matches what php evaluates the literal to', function (string $literal) {
+    expect(parsedStringValue($literal))->toBe(eval("return {$literal};"));
+})->with([
+    // double quoted
+    '"plain"',
+    '"a\nb"', '"a\tb"', '"a\rb"', '"a\vb"', '"a\eb"', '"a\fb"',
+    '"a\\\\b"', '"a\$b"', '"a\"b"', '"a\qb"',
+    '"a\x41b"', '"a\x4b"', '"a\101b"', '"a\7b"', '"a\0b"',
+    '"a\u{1F600}b"', '"a\u{41}b"',
+    '"App\\\\Models\\\\User"', '"C:\\\\path\\\\file"',
+
+    // single quoted
+    "'plain'", "'a\\nb'", "'a\\\\b'", "'a\\'b'", "'a\\qb'", "'App\\Models\\User'",
+
+    // heredoc: same as double quoted, except a quote is never escaped
+    "<<<EOT\nplain\nEOT",
+    "<<<EOT\na\\nb\nEOT",
+    "<<<EOT\na\\\"b\nEOT",
+    "<<<EOT\na\\\\\\\\b\nEOT",
+    "<<<EOT\nl1\nl2\nEOT",
+
+    // nowdoc: nothing is escaped at all
+    "<<<'EOT'\nplain\nEOT",
+    "<<<'EOT'\na\\nb\nEOT",
+    "<<<'EOT'\na\\\\\\\\b\nEOT",
+]);


### PR DESCRIPTION
string values come from `getStringContentsText()`, which is the raw source, so escape sequences are never resolved. the value the server matches against is not the value php produces:

| written | server saw | php produces |
|---|---|---|
| `"App\\Models\\User"` | `App\\Models\\User` | `App\Models\User` |
| `"a\tb"` | `a\tb` | `a` + tab + `b` |
| `"a\x41b"` | `a\x41b` | `aAb` |

that first row is a real false positive, not a theoretical one. app bindings are indexed with single backslashes, so `app('Illuminate\Foundation\Mix')` resolves and `app("Illuminate\\Foundation\\Mix")` reports the binding as missing. same class of thing for any double quoted class string.

this resolves the sequences php actually resolves, per string kind. nowdoc gets nothing, single quotes get `\\` and `\'`, double quotes and heredoc get the full set including octal, `\x` and `\u{}`. heredoc is not identical to double quoted, `\"` keeps its backslash there, which is easy to get wrong.

`tests/Unit/StringEscapeTest.php` checks each literal against `eval()` of the same literal, so php is the oracle rather than my reading of the manual. 34 cases across all four kinds. reverting the parser fails 22 of them.
