### PR TITLE
Fix asset links with leading slashes

### DIFF
--- a/app/Lsp/Features/Assets/AssetDocumentMapper.php
+++ b/app/Lsp/Features/Assets/AssetDocumentMapper.php
@@ -8,8 +8,8 @@ use App\Lsp\Detection\AutocompleteArgument;
 use App\Lsp\Detection\DetectedArgument;
 use App\Lsp\Detection\Pattern;
 use App\Lsp\Features\Support\DocumentMapper;
-use App\Lsp\Support\FileUri;
 use App\Lsp\Project;
+use App\Lsp\Support\FileUri;
 use Illuminate\Support\Collection;
 
 class AssetDocumentMapper extends DocumentMapper
@@ -109,7 +109,7 @@ class AssetDocumentMapper extends DocumentMapper
             return null;
         }
 
-        $asset = $this->assets()->firstWhere('path', $value);
+        $asset = $this->assets()->firstWhere('path', ltrim($value, '/'));
 
         return is_array($asset) ? $asset : null;
     }

--- a/tests/Unit/AssetDocumentMapperTest.php
+++ b/tests/Unit/AssetDocumentMapperTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Lsp\Detection\DetectedArgument;
+use App\Lsp\Features\Assets\AssetDocumentMapper;
+use App\Lsp\Project;
+use App\Lsp\ProjectIndex;
+use App\Lsp\ScriptRunner;
+use App\Lsp\Support\FileUri;
+use Illuminate\Support\Collection;
+
+function assetArgument(string $value): DetectedArgument
+{
+    return new DetectedArgument(
+        item: [],
+        argumentIndex: 0,
+        param: [
+            'type'  => 'string',
+            'value' => $value,
+        ],
+    );
+}
+
+function assetMapper(): AssetDocumentMapper
+{
+    $index = new class extends ProjectIndex
+    {
+        public function __construct() {}
+
+        public function assets(): Collection
+        {
+            return new Collection([
+                [
+                    'path'     => 'images/preview.png',
+                    'fullPath' => '/project/public/images/preview.png',
+                ],
+            ]);
+        }
+    };
+
+    $project = new Project(
+        uri: FileUri::of('file:///project'),
+        init: [],
+        index: $index,
+        scripts: new ScriptRunner('/project', []),
+    );
+
+    return new class($project) extends AssetDocumentMapper
+    {
+        public function findAsset(DetectedArgument $argument): ?array
+        {
+            return $this->find($argument);
+        }
+    };
+}
+
+test('finds assets with or without a leading slash', function () {
+    $mapper = assetMapper();
+
+    expect($mapper->findAsset(assetArgument('images/preview.png')))->not->toBeNull()
+        ->and($mapper->findAsset(assetArgument('/images/preview.png')))->not->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Normalize leading slashes when resolving `asset()` arguments.
- Allow `asset('images/preview.png')` and `asset('/images/preview.png')` to resolve to the same public asset.
- Add a regression test covering both forms.

## Validation

- `./vendor/bin/pest tests/Unit/AssetDocumentMapperTest.php`
- `./vendor/bin/pint --test app/Lsp/Features/Assets/AssetDocumentMapper.php tests/Unit/AssetDocumentMapperTest.php`
- Source LSP smoke test confirmed both forms return the same document link.

The full existing suite currently has unrelated failures because the repository does not contain the `tests/snippets/*.php` fixtures referenced by legacy parser tests.
