### PR TITLE
fix: restore the broken Parser/Detect test suite and run it in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Pest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: "8.4"
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run tests
+        run: ./vendor/bin/pest

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 todo.md
 .env
 /storage/local-results
-/tests/snippets
 /storage/new-parsed
 storage/tree.txt
 /storage/logs

--- a/tests/Unit/DetectTest.php
+++ b/tests/Unit/DetectTest.php
@@ -7,15 +7,6 @@ function detect($values)
     return json_encode($values, JSON_PRETTY_PRINT);
 }
 
-function detectFromArray($values)
-{
-    return array_map(fn ($v) => array_merge([
-        'class'  => null,
-        'method' => null,
-        'params' => [],
-    ], $v), $values);
-}
-
 function result($file)
 {
     $code = fromFile($file);
@@ -27,89 +18,30 @@ function result($file)
 }
 
 test('extract functions and string params', function () {
-    expect(result('detect/routes'))->toBe(detect([
-
+    expect(result('detect/routes'))->toBe(detect(
         [
             [
-                'method' => 'basicFunc',
-                'class'  => null,
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'whatever',
-                        'start' => [
-                            'line'   => 9,
-                            'column' => 10,
-                        ],
-                        'end' => [
-                            'line'   => 9,
-                            'column' => 18,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'name',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'home.show',
-                        'start' => [
-                            'line'   => 11,
-                            'column' => 55,
-                        ],
-                        'end' => [
-                            'line'   => 11,
-                            'column' => 64,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'get',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => '/',
-                        'start' => [
-                            'line'   => 11,
-                            'column' => 11,
-                        ],
-                        'end' => [
-                            'line'   => 11,
-                            'column' => 12,
-                        ],
-                    ],
-                    [
-                        'type'  => 'array',
-                        'value' => [
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'unknown',
-                                    'value' => 'HomeController::class',
-                                ],
-                            ],
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
+                'type'       => 'methodCall',
+                'methodName' => 'name',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
                                     'type'  => 'string',
-                                    'value' => 'show',
+                                    'value' => 'home.show',
                                     'start' => [
-                                        'line'   => 11,
-                                        'column' => 40,
+                                        'line'   => 4,
+                                        'column' => 55,
                                     ],
                                     'end' => [
-                                        'line'   => 11,
-                                        'column' => 44,
+                                        'line'   => 4,
+                                        'column' => 64,
                                     ],
                                 ],
                             ],
@@ -118,238 +50,424 @@ test('extract functions and string params', function () {
                 ],
             ],
             [
-                'method' => 'group',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'      => 'closure',
-                        'arguments' => [],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'middleware',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'signed',
-                        'start' => [
-                            'line'   => 13,
-                            'column' => 18,
-                        ],
-                        'end' => [
-                            'line'   => 13,
-                            'column' => 24,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'name',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'profile.edit',
-                        'start' => [
-                            'line'   => 15,
-                            'column' => 68,
-                        ],
-                        'end' => [
-                            'line'   => 15,
-                            'column' => 80,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'get',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'profile',
-                        'start' => [
-                            'line'   => 15,
-                            'column' => 15,
-                        ],
-                        'end' => [
-                            'line'   => 15,
-                            'column' => 22,
-                        ],
-                    ],
-                    [
-                        'type'  => 'array',
-                        'value' => [
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'unknown',
-                                    'value' => 'ProfileController::class',
-                                ],
-                            ],
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
+                'type'       => 'methodCall',
+                'methodName' => 'get',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 2,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
                                     'type'  => 'string',
-                                    'value' => 'edit',
+                                    'value' => '/',
                                     'start' => [
-                                        'line'   => 15,
-                                        'column' => 53,
+                                        'line'   => 4,
+                                        'column' => 11,
                                     ],
                                     'end' => [
-                                        'line'   => 15,
-                                        'column' => 57,
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'name',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'profile.edit',
-                        'start' => [
-                            'line'   => 15,
-                            'column' => 68,
-                        ],
-                        'end' => [
-                            'line'   => 15,
-                            'column' => 80,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'get',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'profile',
-                        'start' => [
-                            'line'   => 15,
-                            'column' => 15,
-                        ],
-                        'end' => [
-                            'line'   => 15,
-                            'column' => 22,
-                        ],
-                    ],
-                    [
-                        'type'  => 'array',
-                        'value' => [
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'unknown',
-                                    'value' => 'ProfileController::class',
-                                ],
-                            ],
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'string',
-                                    'value' => 'edit',
-                                    'start' => [
-                                        'line'   => 15,
-                                        'column' => 53,
-                                    ],
-                                    'end' => [
-                                        'line'   => 15,
-                                        'column' => 57,
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'group',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'      => 'closure',
-                        'arguments' => [],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'middleware',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'array',
-                        'value' => [
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'string',
-                                    'value' => 'auth',
-                                    'start' => [
-                                        'line'   => 19,
-                                        'column' => 4,
-                                    ],
-                                    'end' => [
-                                        'line'   => 19,
-                                        'column' => 8,
-                                    ],
-                                ],
-                            ],
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'string',
-                                    'value' => 'verified',
-                                    'start' => [
-                                        'line'   => 20,
-                                        'column' => 4,
-                                    ],
-                                    'end' => [
-                                        'line'   => 20,
+                                        'line'   => 4,
                                         'column' => 12,
                                     ],
                                 ],
                             ],
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
+                        ],
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'     => 'array',
+                                    'children' => [
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'       => 'methodCall',
+                                                'methodName' => null,
+                                                'className'  => 'HomeController',
+                                                'arguments'  => [
+                                                    'type'                => 'arguments',
+                                                    'autocompletingIndex' => 0,
+                                                    'children'            => [],
+                                                ],
+                                                'children' => [],
+                                            ],
+                                        ],
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'  => 'string',
+                                                'value' => 'show',
+                                                'start' => [
+                                                    'line'   => 4,
+                                                    'column' => 40,
+                                                ],
+                                                'end' => [
+                                                    'line'   => 4,
+                                                    'column' => 44,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
                                 ],
-                                'value' => [
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'group',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'       => 'closure',
+                                    'parameters' => [],
+                                    'children'   => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'middleware',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
                                     'type'  => 'string',
-                                    'value' => 'within-current-organization',
+                                    'value' => 'signed',
                                     'start' => [
-                                        'line'   => 21,
-                                        'column' => 4,
+                                        'line'   => 6,
+                                        'column' => 18,
                                     ],
                                     'end' => [
-                                        'line'   => 21,
+                                        'line'   => 6,
+                                        'column' => 24,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'name',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'  => 'string',
+                                    'value' => 'profile.edit',
+                                    'start' => [
+                                        'line'   => 7,
+                                        'column' => 68,
+                                    ],
+                                    'end' => [
+                                        'line'   => 7,
+                                        'column' => 80,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'get',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 2,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'  => 'string',
+                                    'value' => 'profile',
+                                    'start' => [
+                                        'line'   => 7,
+                                        'column' => 15,
+                                    ],
+                                    'end' => [
+                                        'line'   => 7,
+                                        'column' => 22,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'     => 'array',
+                                    'children' => [
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'       => 'methodCall',
+                                                'methodName' => null,
+                                                'className'  => 'ProfileController',
+                                                'arguments'  => [
+                                                    'type'                => 'arguments',
+                                                    'autocompletingIndex' => 0,
+                                                    'children'            => [],
+                                                ],
+                                                'children' => [],
+                                            ],
+                                        ],
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'  => 'string',
+                                                'value' => 'edit',
+                                                'start' => [
+                                                    'line'   => 7,
+                                                    'column' => 53,
+                                                ],
+                                                'end' => [
+                                                    'line'   => 7,
+                                                    'column' => 57,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'group',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'       => 'closure',
+                                    'parameters' => [],
+                                    'children'   => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'middleware',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'     => 'array',
+                                    'children' => [
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'  => 'string',
+                                                'value' => 'auth',
+                                                'start' => [
+                                                    'line'   => 10,
+                                                    'column' => 19,
+                                                ],
+                                                'end' => [
+                                                    'line'   => 10,
+                                                    'column' => 23,
+                                                ],
+                                            ],
+                                        ],
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'  => 'string',
+                                                'value' => 'verified',
+                                                'start' => [
+                                                    'line'   => 10,
+                                                    'column' => 27,
+                                                ],
+                                                'end' => [
+                                                    'line'   => 10,
+                                                    'column' => 35,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'name',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'  => 'string',
+                                    'value' => 'dashboard',
+                                    'start' => [
+                                        'line'   => 11,
+                                        'column' => 72,
+                                    ],
+                                    'end' => [
+                                        'line'   => 11,
+                                        'column' => 81,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'get',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 2,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'  => 'string',
+                                    'value' => 'dashboard',
+                                    'start' => [
+                                        'line'   => 11,
+                                        'column' => 15,
+                                    ],
+                                    'end' => [
+                                        'line'   => 11,
+                                        'column' => 24,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'     => 'array',
+                                    'children' => [
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'       => 'methodCall',
+                                                'methodName' => null,
+                                                'className'  => 'DashboardController',
+                                                'arguments'  => [
+                                                    'type'                => 'arguments',
+                                                    'autocompletingIndex' => 0,
+                                                    'children'            => [],
+                                                ],
+                                                'children' => [],
+                                            ],
+                                        ],
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'  => 'string',
+                                                'value' => 'show',
+                                                'start' => [
+                                                    'line'   => 11,
+                                                    'column' => 57,
+                                                ],
+                                                'end' => [
+                                                    'line'   => 11,
+                                                    'column' => 61,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'name',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'  => 'string',
+                                    'value' => 'gitlab.webhook.store',
+                                    'start' => [
+                                        'line'   => 17,
+                                        'column' => 11,
+                                    ],
+                                    'end' => [
+                                        'line'   => 17,
                                         'column' => 31,
                                     ],
                                 ],
@@ -359,103 +477,97 @@ test('extract functions and string params', function () {
                 ],
             ],
             [
-                'method' => 'name',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'dashboard',
-                        'start' => [
-                            'line'   => 23,
-                            'column' => 72,
-                        ],
-                        'end' => [
-                            'line'   => 23,
-                            'column' => 81,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'get',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'dashboard',
-                        'start' => [
-                            'line'   => 23,
-                            'column' => 15,
-                        ],
-                        'end' => [
-                            'line'   => 23,
-                            'column' => 81,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'name',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'dashboard',
-                        'start' => [
-                            'line'   => 23,
-                            'column' => 72,
-                        ],
-                        'end' => [
-                            'line'   => 23,
-                            'column' => 81,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'get',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'dashboard',
-                        'start' => [
-                            'line'   => 23,
-                            'column' => 15,
-                        ],
-                        'end' => [
-                            'line'   => 23,
-                            'column' => 81,
-                        ],
-                    ],
-                    [
-                        'type'  => 'array',
-                        'value' => [
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'unknown',
-                                    'value' => 'DashboardController::class',
+                'type'       => 'methodCall',
+                'methodName' => 'middleware',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'       => 'methodCall',
+                                    'methodName' => null,
+                                    'className'  => 'VerifyGitLabWebhookRequest',
+                                    'arguments'  => [
+                                        'type'                => 'arguments',
+                                        'autocompletingIndex' => 0,
+                                        'children'            => [],
+                                    ],
+                                    'children' => [],
                                 ],
                             ],
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'type'       => 'methodCall',
+                'methodName' => 'post',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 2,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
                                     'type'  => 'string',
-                                    'value' => 'show',
+                                    'value' => 'gitlab/webhook',
                                     'start' => [
-                                        'line'   => 23,
-                                        'column' => 57,
+                                        'line'   => 15,
+                                        'column' => 11,
                                     ],
                                     'end' => [
-                                        'line'   => 23,
-                                        'column' => 61,
+                                        'line'   => 15,
+                                        'column' => 25,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
+                                    'type'     => 'array',
+                                    'children' => [
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'       => 'methodCall',
+                                                'methodName' => null,
+                                                'className'  => 'GitLabWebhookController',
+                                                'arguments'  => [
+                                                    'type'                => 'arguments',
+                                                    'autocompletingIndex' => 0,
+                                                    'children'            => [],
+                                                ],
+                                                'children' => [],
+                                            ],
+                                        ],
+                                        [
+                                            'type'  => 'array_item',
+                                            'key'   => null,
+                                            'value' => [
+                                                'type'  => 'string',
+                                                'value' => 'store',
+                                                'start' => [
+                                                    'line'   => 15,
+                                                    'column' => 62,
+                                                ],
+                                                'end' => [
+                                                    'line'   => 15,
+                                                    'column' => 67,
+                                                ],
+                                            ],
+                                        ],
                                     ],
                                 ],
                             ],
@@ -464,95 +576,27 @@ test('extract functions and string params', function () {
                 ],
             ],
             [
-                'method' => 'name',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'gitlab.webhook.store',
-                        'start' => [
-                            'line'   => 30,
-                            'column' => 11,
-                        ],
-                        'end' => [
-                            'line'   => 30,
-                            'column' => 31,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'middleware',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'unknown',
-                        'value' => 'VerifyGitLabWebhookRequest::class',
-                    ],
-                ],
-            ],
-            [
-                'method' => 'withoutMiddleware',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'web',
-                        'start' => [
-                            'line'   => 28,
-                            'column' => 24,
-                        ],
-                        'end' => [
-                            'line'   => 28,
-                            'column' => 27,
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'method' => 'post',
-                'class'  => 'Illuminate\\Support\\Facades\\Route',
-                'params' => [
-                    [
-                        'type'  => 'string',
-                        'value' => 'gitlab/webhook',
-                        'start' => [
-                            'line'   => 27,
-                            'column' => 12,
-                        ],
-                        'end' => [
-                            'line'   => 27,
-                            'column' => 26,
-                        ],
-                    ],
-                    [
-                        'type'  => 'array',
-                        'value' => [
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
-                                    'type'  => 'unknown',
-                                    'value' => 'GitLabWebhookController::class',
-                                ],
-                            ],
-                            [
-                                'key' => [
-                                    'type'  => 'null',
-                                    'value' => null,
-                                ],
-                                'value' => [
+                'type'       => 'methodCall',
+                'methodName' => 'withoutMiddleware',
+                'className'  => 'Illuminate\\Support\\Facades\\Route',
+                'arguments'  => [
+                    'type'                => 'arguments',
+                    'autocompletingIndex' => 1,
+                    'children'            => [
+                        [
+                            'type'     => 'argument',
+                            'name'     => null,
+                            'children' => [
+                                [
                                     'type'  => 'string',
-                                    'value' => 'store',
+                                    'value' => 'web',
                                     'start' => [
-                                        'line'   => 27,
-                                        'column' => 63,
+                                        'line'   => 14,
+                                        'column' => 25,
                                     ],
                                     'end' => [
-                                        'line'   => 27,
-                                        'column' => 68,
+                                        'line'   => 14,
+                                        'column' => 28,
                                     ],
                                 ],
                             ],
@@ -560,7 +604,6 @@ test('extract functions and string params', function () {
                     ],
                 ],
             ],
-        ],
-
-    ]));
+        ]
+    ));
 });

--- a/tests/Unit/ParserTest.php
+++ b/tests/Unit/ParserTest.php
@@ -12,26 +12,6 @@ function createContext($values)
     return json_encode(['type' => 'base', 'children' => $values], JSON_PRETTY_PRINT);
 }
 
-function contextFromArray($values)
-{
-    return array_merge([
-        'classDefinition'        => null,
-        'implements'             => [],
-        'extends'                => null,
-        'methodDefinition'       => null,
-        'methodDefinitionParams' => [],
-        'methodExistingArgs'     => [],
-        'classUsed'              => null,
-        'methodUsed'             => null,
-        'parent'                 => null,
-        'variables'              => [],
-        'definedProperties'      => [],
-        'fillingInArrayKey'      => false,
-        'fillingInArrayValue'    => false,
-        'paramIndex'             => 0,
-    ], $values);
-}
-
 function contextResult($file, $dump = false)
 {
     $code = fromFile($file);
@@ -55,10 +35,14 @@ test('basic function', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'render',
-            'class'          => null,
-            'arguments'      => [],
-            'children'       => [],
+            'methodName'     => 'render',
+            'className'      => null,
+            'arguments'      => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 0,
+                'children'            => [],
+            ],
+            'children' => [],
         ],
     ]));
 });
@@ -73,12 +57,22 @@ test('basic function with params', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'render',
-            'class'          => null,
+            'methodName'     => 'render',
+            'className'      => null,
             'arguments'      => [
-                [
-                    'type'  => 'string',
-                    'value' => 'my-view',
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'my-view',
+                            ],
+                        ],
+                    ],
                 ],
             ],
             'children' => [],
@@ -91,10 +85,14 @@ test('basic static method', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'where',
-            'class'          => 'App\Models\User',
-            'arguments'      => [],
-            'children'       => [],
+            'methodName'     => 'where',
+            'className'      => 'App\Models\User',
+            'arguments'      => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 0,
+                'children'            => [],
+            ],
+            'children' => [],
         ],
     ]));
 });
@@ -104,12 +102,22 @@ test('basic static method with params', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'where',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'where',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'  => 'string',
-                    'value' => 'email',
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'email',
+                            ],
+                        ],
+                    ],
                 ],
             ],
             'children' => [],
@@ -122,27 +130,53 @@ test('chained static method with params', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'orWhere',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'orWhere',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'  => 'string',
-                    'value' => 'name',
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'name',
+                            ],
+                        ],
+                    ],
                 ],
             ],
             'children' => [
                 [
-                    'type'      => 'methodCall',
-                    'name'      => 'where',
-                    'class'     => 'App\Models\User',
-                    'arguments' => [
-                        [
-                            'type'  => 'string',
-                            'value' => 'email',
-                        ],
-                        [
-                            'type'  => 'string',
-                            'value' => '',
+                    'type'       => 'methodCall',
+                    'methodName' => 'where',
+                    'className'  => 'App\Models\User',
+                    'arguments'  => [
+                        'type'                => 'arguments',
+                        'autocompletingIndex' => 2,
+                        'children'            => [
+                            [
+                                'type'     => 'argument',
+                                'name'     => null,
+                                'children' => [
+                                    [
+                                        'type'  => 'string',
+                                        'value' => 'email',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'type'     => 'argument',
+                                'name'     => null,
+                                'children' => [
+                                    [
+                                        'type'  => 'string',
+                                        'value' => '',
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                     'children' => [],
@@ -159,8 +193,13 @@ test('basic method', function () {
             'name'  => 'user',
             'value' => [
                 [
-                    'type'     => 'object',
-                    'name'     => 'App\Models\User',
+                    'type'      => 'object',
+                    'className' => 'App\Models\User',
+                    'arguments' => [
+                        'type'                => 'arguments',
+                        'autocompletingIndex' => 0,
+                        'children'            => [],
+                    ],
                     'children' => [],
                 ],
             ],
@@ -168,10 +207,14 @@ test('basic method', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'where',
-            'class'          => 'App\Models\User',
-            'arguments'      => [],
-            'children'       => [],
+            'methodName'     => 'where',
+            'className'      => 'App\Models\User',
+            'arguments'      => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 0,
+                'children'            => [],
+            ],
+            'children' => [],
         ],
     ]));
 });
@@ -183,8 +226,13 @@ test('basic method with params', function () {
             'name'  => 'user',
             'value' => [
                 [
-                    'type'     => 'object',
-                    'name'     => 'App\Models\User',
+                    'type'      => 'object',
+                    'className' => 'App\Models\User',
+                    'arguments' => [
+                        'type'                => 'arguments',
+                        'autocompletingIndex' => 0,
+                        'children'            => [],
+                    ],
                     'children' => [],
                 ],
             ],
@@ -192,12 +240,22 @@ test('basic method with params', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'where',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'where',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'  => 'string',
-                    'value' => 'email',
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'email',
+                            ],
+                        ],
+                    ],
                 ],
             ],
             'children' => [],
@@ -212,8 +270,13 @@ test('chained method with params', function () {
             'name'  => 'user',
             'value' => [
                 [
-                    'type'     => 'object',
-                    'name'     => 'App\Models\User',
+                    'type'      => 'object',
+                    'className' => 'App\Models\User',
+                    'arguments' => [
+                        'type'                => 'arguments',
+                        'autocompletingIndex' => 0,
+                        'children'            => [],
+                    ],
                     'children' => [],
                 ],
             ],
@@ -221,27 +284,53 @@ test('chained method with params', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'orWhere',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'orWhere',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'  => 'string',
-                    'value' => 'name',
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => 'name',
+                            ],
+                        ],
+                    ],
                 ],
             ],
             'children' => [
                 [
-                    'type'      => 'methodCall',
-                    'name'      => 'where',
-                    'class'     => 'App\Models\User',
-                    'arguments' => [
-                        [
-                            'type'  => 'string',
-                            'value' => 'email',
-                        ],
-                        [
-                            'type'  => 'string',
-                            'value' => '',
+                    'type'       => 'methodCall',
+                    'methodName' => 'where',
+                    'className'  => 'App\Models\User',
+                    'arguments'  => [
+                        'type'                => 'arguments',
+                        'autocompletingIndex' => 2,
+                        'children'            => [
+                            [
+                                'type'     => 'argument',
+                                'name'     => null,
+                                'children' => [
+                                    [
+                                        'type'  => 'string',
+                                        'value' => 'email',
+                                    ],
+                                ],
+                            ],
+                            [
+                                'type'     => 'argument',
+                                'name'     => null,
+                                'children' => [
+                                    [
+                                        'type'  => 'string',
+                                        'value' => '',
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                     'children' => [],
@@ -256,25 +345,39 @@ test('anonymous function as param', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'where',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'where',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'       => 'closure',
-                    'parameters' => [
-                        [
-                            'types' => ['Illuminate\Database\Query\Builder'],
-                            'name'  => 'q',
-                        ],
-                    ],
-                    'children' => [
-                        [
-                            'type'           => 'methodCall',
-                            'autocompleting' => true,
-                            'name'           => 'whereIn',
-                            'class'          => 'Illuminate\Database\Query\Builder',
-                            'arguments'      => [],
-                            'children'       => [],
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'       => 'closure',
+                                'parameters' => [
+                                    [
+                                        'types' => ['Illuminate\Database\Query\Builder'],
+                                        'name'  => 'q',
+                                    ],
+                                ],
+                                'children' => [
+                                    [
+                                        'type'           => 'methodCall',
+                                        'autocompleting' => true,
+                                        'methodName'     => 'whereIn',
+                                        'className'      => 'Illuminate\Database\Query\Builder',
+                                        'arguments'      => [
+                                            'type'                => 'arguments',
+                                            'autocompletingIndex' => 0,
+                                            'children'            => [],
+                                        ],
+                                        'children' => [],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
@@ -289,25 +392,39 @@ test('arrow function as param', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'where',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'where',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'       => 'closure',
-                    'parameters' => [
-                        [
-                            'types' => ['Illuminate\Database\Query\Builder'],
-                            'name'  => 'q',
-                        ],
-                    ],
-                    'children' => [
-                        [
-                            'type'           => 'methodCall',
-                            'autocompleting' => true,
-                            'name'           => 'whereIn',
-                            'class'          => 'Illuminate\Database\Query\Builder',
-                            'arguments'      => [],
-                            'children'       => [],
+                'type'                => 'arguments',
+                'autocompletingIndex' => 1,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'       => 'closure',
+                                'parameters' => [
+                                    [
+                                        'types' => ['Illuminate\Database\Query\Builder'],
+                                        'name'  => 'q',
+                                    ],
+                                ],
+                                'children' => [
+                                    [
+                                        'type'           => 'methodCall',
+                                        'autocompleting' => true,
+                                        'methodName'     => 'whereIn',
+                                        'className'      => 'Illuminate\Database\Query\Builder',
+                                        'arguments'      => [
+                                            'type'                => 'arguments',
+                                            'autocompletingIndex' => 0,
+                                            'children'            => [],
+                                        ],
+                                        'children' => [],
+                                    ],
+                                ],
+                            ],
                         ],
                     ],
                 ],
@@ -322,36 +439,66 @@ test('nested functions', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'get',
-            'class'          => 'Route',
+            'methodName'     => 'get',
+            'className'      => 'Route',
             'arguments'      => [
-                [
-                    'type'  => 'string',
-                    'value' => '/',
-                ],
-                [
-                    'type'       => 'closure',
-                    'parameters' => [],
-                    'children'   => [
-                        [
-                            'type'      => 'methodCall',
-                            'name'      => 'trans',
-                            'class'     => null,
-                            'arguments' => [
-                                [
-                                    'type'  => 'string',
-                                    'value' => 'auth.throttle',
+                'type'                => 'arguments',
+                'autocompletingIndex' => 2,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'  => 'string',
+                                'value' => '/',
+                            ],
+                        ],
+                    ],
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'       => 'closure',
+                                'parameters' => [],
+                                'children'   => [
+                                    [
+                                        'type'       => 'methodCall',
+                                        'methodName' => 'trans',
+                                        'className'  => null,
+                                        'arguments'  => [
+                                            'type'                => 'arguments',
+                                            'autocompletingIndex' => 1,
+                                            'children'            => [
+                                                [
+                                                    'type'     => 'argument',
+                                                    'name'     => null,
+                                                    'children' => [
+                                                        [
+                                                            'type'  => 'string',
+                                                            'value' => 'auth.throttle',
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                        'children' => [],
+                                    ],
+                                    [
+                                        'type'           => 'methodCall',
+                                        'autocompleting' => true,
+                                        'methodName'     => 'where',
+                                        'className'      => 'App\Models\User',
+                                        'arguments'      => [
+                                            'type'                => 'arguments',
+                                            'autocompletingIndex' => 0,
+                                            'children'            => [],
+                                        ],
+                                        'children' => [],
+                                    ],
                                 ],
                             ],
-                            'children' => [],
-                        ],
-                        [
-                            'type'           => 'methodCall',
-                            'autocompleting' => true,
-                            'name'           => 'where',
-                            'class'          => 'App\Models\User',
-                            'arguments'      => [],
-                            'children'       => [],
                         ],
                     ],
                 ],
@@ -366,42 +513,57 @@ test('array with arrow function', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'with',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'with',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'           => 'array',
-                    'autocompleting' => true,
-                    'children'       => [
-                        [
-                            'key' => [
-                                'type'  => 'string',
-                                'value' => 'team',
-                            ],
-                            'value' => [
-                                'type'       => 'closure',
-                                'parameters' => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 0,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'           => 'array',
+                                'autocompleting' => true,
+                                'children'       => [
                                     [
-                                        'types' => ['Illuminate\Database\Query\Builder'],
-                                        'name'  => 'q',
+                                        'type' => 'array_item',
+                                        'key'  => [
+                                            'type'  => 'string',
+                                            'value' => 'team',
+                                        ],
+                                        'value' => [
+                                            'type'       => 'closure',
+                                            'parameters' => [
+                                                [
+                                                    'types' => ['Illuminate\Database\Query\Builder'],
+                                                    'name'  => 'q',
+                                                ],
+                                            ],
+                                            'children' => [
+                                                [
+                                                    'type'           => 'methodCall',
+                                                    'autocompleting' => true,
+                                                    'methodName'     => 'where',
+                                                    'className'      => 'Illuminate\Database\Query\Builder',
+                                                    'arguments'      => [
+                                                        'type'                => 'arguments',
+                                                        'autocompletingIndex' => 0,
+                                                        'children'            => [],
+                                                    ],
+                                                    'children' => [],
+                                                ],
+                                            ],
+                                        ],
+                                        'autocompletingValue' => true,
                                     ],
                                 ],
-                                'children' => [
-                                    [
-                                        'type'           => 'methodCall',
-                                        'autocompleting' => true,
-                                        'name'           => 'where',
-                                        'class'          => 'Illuminate\Database\Query\Builder',
-                                        'arguments'      => [],
-                                        'children'       => [],
-                                    ],
-                                ],
+                                'autocompletingKey'   => false,
+                                'autocompletingValue' => true,
                             ],
-                            'autocompletingValue' => true,
                         ],
                     ],
-                    'autocompletingKey'   => false,
-                    'autocompletingValue' => true,
                 ],
             ],
             'children' => [],
@@ -414,75 +576,107 @@ test('array with arrow function several keys', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'with',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'with',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'           => 'array',
-                    'autocompleting' => true,
-                    'children'       => [
-                        [
-                            'key' => [
-                                'type'  => 'string',
-                                'value' => 'team',
-                            ],
-                            'value' => [
-                                'type'       => 'closure',
-                                'parameters' => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 0,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'           => 'array',
+                                'autocompleting' => true,
+                                'children'       => [
                                     [
-                                        'types' => ['Illuminate\Database\Query\Builder'],
-                                        'name'  => 'q',
-                                    ],
-                                ],
-                                'children' => [
-                                    [
-                                        'type'      => 'methodCall',
-                                        'name'      => 'where',
-                                        'class'     => 'Illuminate\Database\Query\Builder',
-                                        'arguments' => [
-                                            [
-                                                'type'  => 'string',
-                                                'value' => '',
+                                        'type' => 'array_item',
+                                        'key'  => [
+                                            'type'  => 'string',
+                                            'value' => 'team',
+                                        ],
+                                        'value' => [
+                                            'type'       => 'closure',
+                                            'parameters' => [
+                                                [
+                                                    'types' => ['Illuminate\Database\Query\Builder'],
+                                                    'name'  => 'q',
+                                                ],
                                             ],
-                                            [
-                                                'type'  => 'string',
-                                                'value' => '',
+                                            'children' => [
+                                                [
+                                                    'type'       => 'methodCall',
+                                                    'methodName' => 'where',
+                                                    'className'  => 'Illuminate\Database\Query\Builder',
+                                                    'arguments'  => [
+                                                        'type'                => 'arguments',
+                                                        'autocompletingIndex' => 2,
+                                                        'children'            => [
+                                                            [
+                                                                'type'     => 'argument',
+                                                                'name'     => null,
+                                                                'children' => [
+                                                                    [
+                                                                        'type'  => 'string',
+                                                                        'value' => '',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                            [
+                                                                'type'     => 'argument',
+                                                                'name'     => null,
+                                                                'children' => [
+                                                                    [
+                                                                        'type'  => 'string',
+                                                                        'value' => '',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                    'children' => [],
+                                                ],
                                             ],
                                         ],
-                                        'children' => [],
                                     ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'key' => [
-                                'type'  => 'string',
-                                'value' => 'organization',
-                            ],
-                            'value' => [
-                                'type'       => 'closure',
-                                'parameters' => [
                                     [
-                                        'types' => [],
-                                        'name'  => 'q',
+                                        'type' => 'array_item',
+                                        'key'  => [
+                                            'type'  => 'string',
+                                            'value' => 'organization',
+                                        ],
+                                        'value' => [
+                                            'type'       => 'closure',
+                                            'parameters' => [
+                                                [
+                                                    'types' => [],
+                                                    'name'  => 'q',
+                                                ],
+                                            ],
+                                            'children' => [
+                                                [
+                                                    'type'           => 'methodCall',
+                                                    'autocompleting' => true,
+                                                    'methodName'     => 'whereIn',
+                                                    'className'      => null,
+                                                    'arguments'      => [
+                                                        'type'                => 'arguments',
+                                                        'autocompletingIndex' => 0,
+                                                        'children'            => [],
+                                                    ],
+                                                    'children' => [],
+                                                ],
+                                            ],
+                                        ],
+                                        'autocompletingValue' => true,
                                     ],
                                 ],
-                                'children' => [
-                                    [
-                                        'type'           => 'methodCall',
-                                        'autocompleting' => true,
-                                        'name'           => 'whereIn',
-                                        'class'          => null,
-                                        'arguments'      => [],
-                                        'children'       => [],
-                                    ],
-                                ],
+                                'autocompletingKey'   => false,
+                                'autocompletingValue' => true,
                             ],
-                            'autocompletingValue' => true,
                         ],
                     ],
-                    'autocompletingKey'   => false,
-                    'autocompletingValue' => true,
                 ],
             ],
             'children' => [],
@@ -494,14 +688,14 @@ test('eloquent make from set variable', function () {
     expect(contextResult('eloquent-make-from-set-variable'))->toBe(createContext([
         [
             'type'       => 'classDefinition',
-            'name'       => 'App\Http\Controllers\ProviderController',
+            'className'  => 'App\Http\Controllers\ProviderController',
             'extends'    => 'App\Http\Controllers\Controller',
             'implements' => [],
             'properties' => [],
             'children'   => [
                 [
                     'type'       => 'methodDefinition',
-                    'name'       => 'store',
+                    'methodName' => 'store',
                     'parameters' => [
                         [
                             'types' => ['Illuminate\Http\Request'],
@@ -516,15 +710,25 @@ test('eloquent make from set variable', function () {
                                 [
                                     'type'           => 'methodCall',
                                     'autocompleting' => true,
-                                    'name'           => 'make',
-                                    'class'          => 'App\Models\Provider',
+                                    'methodName'     => 'make',
+                                    'className'      => 'App\Models\Provider',
                                     'arguments'      => [
-                                        [
-                                            'type'                => 'array',
-                                            'autocompleting'      => true,
-                                            'children'            => [],
-                                            'autocompletingKey'   => true,
-                                            'autocompletingValue' => true,
+                                        'type'                => 'arguments',
+                                        'autocompletingIndex' => 0,
+                                        'children'            => [
+                                            [
+                                                'type'     => 'argument',
+                                                'name'     => null,
+                                                'children' => [
+                                                    [
+                                                        'type'                => 'array',
+                                                        'autocompleting'      => true,
+                                                        'children'            => [],
+                                                        'autocompletingKey'   => true,
+                                                        'autocompletingValue' => true,
+                                                    ],
+                                                ],
+                                            ],
                                         ],
                                     ],
                                     'children' => [],
@@ -543,80 +747,118 @@ test('array with arrow function several keys and second param', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'with',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'with',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'           => 'array',
-                    'autocompleting' => true,
-                    'children'       => [
-                        [
-                            'key' => [
-                                'type'  => 'string',
-                                'value' => 'team',
-                            ],
-                            'value' => [
-                                'type'       => 'closure',
-                                'parameters' => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 0,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'           => 'array',
+                                'autocompleting' => true,
+                                'children'       => [
                                     [
-                                        'types' => ['Illuminate\Database\Query\Builder'],
-                                        'name'  => 'q',
-                                    ],
-                                ],
-                                'children' => [
-                                    [
-                                        'type'      => 'methodCall',
-                                        'name'      => 'where',
-                                        'class'     => 'Illuminate\Database\Query\Builder',
-                                        'arguments' => [
-                                            [
-                                                'type'  => 'string',
-                                                'value' => '',
+                                        'type' => 'array_item',
+                                        'key'  => [
+                                            'type'  => 'string',
+                                            'value' => 'team',
+                                        ],
+                                        'value' => [
+                                            'type'       => 'closure',
+                                            'parameters' => [
+                                                [
+                                                    'types' => ['Illuminate\Database\Query\Builder'],
+                                                    'name'  => 'q',
+                                                ],
                                             ],
-                                            [
-                                                'type'  => 'string',
-                                                'value' => '',
+                                            'children' => [
+                                                [
+                                                    'type'       => 'methodCall',
+                                                    'methodName' => 'where',
+                                                    'className'  => 'Illuminate\Database\Query\Builder',
+                                                    'arguments'  => [
+                                                        'type'                => 'arguments',
+                                                        'autocompletingIndex' => 2,
+                                                        'children'            => [
+                                                            [
+                                                                'type'     => 'argument',
+                                                                'name'     => null,
+                                                                'children' => [
+                                                                    [
+                                                                        'type'  => 'string',
+                                                                        'value' => '',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                            [
+                                                                'type'     => 'argument',
+                                                                'name'     => null,
+                                                                'children' => [
+                                                                    [
+                                                                        'type'  => 'string',
+                                                                        'value' => '',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                    'children' => [],
+                                                ],
                                             ],
                                         ],
-                                        'children' => [],
                                     ],
-                                ],
-                            ],
-                        ],
-                        [
-                            'key' => [
-                                'type'  => 'string',
-                                'value' => 'organization',
-                            ],
-                            'value' => [
-                                'type'       => 'closure',
-                                'parameters' => [
                                     [
-                                        'types' => [],
-                                        'name'  => 'q',
-                                    ],
-                                ],
-                                'children' => [
-                                    [
-                                        'type'           => 'methodCall',
-                                        'autocompleting' => true,
-                                        'name'           => 'whereIn',
-                                        'class'          => null,
-                                        'arguments'      => [
-                                            [
-                                                'type'  => 'string',
-                                                'value' => '',
+                                        'type' => 'array_item',
+                                        'key'  => [
+                                            'type'  => 'string',
+                                            'value' => 'organization',
+                                        ],
+                                        'value' => [
+                                            'type'       => 'closure',
+                                            'parameters' => [
+                                                [
+                                                    'types' => [],
+                                                    'name'  => 'q',
+                                                ],
+                                            ],
+                                            'children' => [
+                                                [
+                                                    'type'           => 'methodCall',
+                                                    'autocompleting' => true,
+                                                    'methodName'     => 'whereIn',
+                                                    'className'      => null,
+                                                    'arguments'      => [
+                                                        'type'                => 'arguments',
+                                                        'autocompletingIndex' => 1,
+                                                        'children'            => [
+                                                            [
+                                                                'type'     => 'argument',
+                                                                'name'     => null,
+                                                                'children' => [
+                                                                    [
+                                                                        'type'  => 'string',
+                                                                        'value' => '',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                    'children' => [],
+                                                ],
                                             ],
                                         ],
-                                        'children' => [],
+                                        'autocompletingValue' => true,
                                     ],
                                 ],
+                                'autocompletingKey'   => false,
+                                'autocompletingValue' => true,
                             ],
-                            'autocompletingValue' => true,
                         ],
                     ],
-                    'autocompletingKey'   => false,
-                    'autocompletingValue' => true,
                 ],
             ],
             'children' => [],
@@ -629,45 +871,76 @@ test('array with arrow function missing second key', function () {
         [
             'type'           => 'methodCall',
             'autocompleting' => true,
-            'name'           => 'with',
-            'class'          => 'App\Models\User',
+            'methodName'     => 'with',
+            'className'      => 'App\Models\User',
             'arguments'      => [
-                [
-                    'type'           => 'array',
-                    'autocompleting' => true,
-                    'children'       => [
-                        [
-                            'key' => [
-                                'type'  => 'string',
-                                'value' => 'team',
-                            ],
-                            'value' => [
-                                'type'       => 'closure',
-                                'parameters' => [
+                'type'                => 'arguments',
+                'autocompletingIndex' => 0,
+                'children'            => [
+                    [
+                        'type'     => 'argument',
+                        'name'     => null,
+                        'children' => [
+                            [
+                                'type'           => 'array',
+                                'autocompleting' => true,
+                                'children'       => [
                                     [
-                                        'types' => ['Illuminate\Database\Query\Builder'],
-                                        'name'  => 'q',
-                                    ],
-                                ],
-                                'children' => [
-                                    [
-                                        'type'      => 'methodCall',
-                                        'name'      => 'where',
-                                        'class'     => 'Illuminate\Database\Query\Builder',
-                                        'arguments' => [
-                                            [
-                                                'type'  => 'string',
-                                                'value' => '',
+                                        'type' => 'array_item',
+                                        'key'  => [
+                                            'type'  => 'string',
+                                            'value' => 'team',
+                                        ],
+                                        'value' => [
+                                            'type'       => 'closure',
+                                            'parameters' => [
+                                                [
+                                                    'types' => ['Illuminate\Database\Query\Builder'],
+                                                    'name'  => 'q',
+                                                ],
+                                            ],
+                                            'children' => [
+                                                [
+                                                    'type'       => 'methodCall',
+                                                    'methodName' => 'where',
+                                                    'className'  => 'Illuminate\Database\Query\Builder',
+                                                    'arguments'  => [
+                                                        'type'                => 'arguments',
+                                                        'autocompletingIndex' => 2,
+                                                        'children'            => [
+                                                            [
+                                                                'type'     => 'argument',
+                                                                'name'     => null,
+                                                                'children' => [
+                                                                    [
+                                                                        'type'  => 'string',
+                                                                        'value' => '',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                            [
+                                                                'type'     => 'argument',
+                                                                'name'     => null,
+                                                                'children' => [
+                                                                    [
+                                                                        'type'  => 'string',
+                                                                        'value' => '',
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                    'children' => [],
+                                                ],
                                             ],
                                         ],
-                                        'children' => [],
                                     ],
                                 ],
+                                'autocompletingKey'   => true,
+                                'autocompletingValue' => false,
                             ],
                         ],
                     ],
-                    'autocompletingKey'   => true,
-                    'autocompletingValue' => false,
                 ],
             ],
             'children' => [],
@@ -679,7 +952,7 @@ test('this reference', function () {
     expect(contextResult('this-reference'))->toBe(createContext([
         [
             'type'       => 'classDefinition',
-            'name'       => 'App\Commands\MyCommand',
+            'className'  => 'App\Commands\MyCommand',
             'extends'    => 'Vendor\Package\Thing',
             'implements' => ['Vendor\Package\Contracts\BigContract', 'Vendor\Package\Support\Contracts\SmallContract'],
             'properties' => [
@@ -691,7 +964,7 @@ test('this reference', function () {
             'children' => [
                 [
                     'type'       => 'methodDefinition',
-                    'name'       => 'render',
+                    'methodName' => 'render',
                     'parameters' => [
                         [
                             'types' => ['array'],
@@ -702,21 +975,35 @@ test('this reference', function () {
                         [
                             'type'           => 'methodCall',
                             'autocompleting' => true,
-                            'name'           => 'where',
-                            'class'          => 'App\Models\User',
+                            'methodName'     => 'where',
+                            'className'      => 'App\Models\User',
                             'arguments'      => [
-                                [
-                                    'type'  => 'string',
-                                    'value' => 'url',
+                                'type'                => 'arguments',
+                                'autocompletingIndex' => 1,
+                                'children'            => [
+                                    [
+                                        'type'     => 'argument',
+                                        'name'     => null,
+                                        'children' => [
+                                            [
+                                                'type'  => 'string',
+                                                'value' => 'url',
+                                            ],
+                                        ],
+                                    ],
                                 ],
                             ],
                             'children' => [
                                 [
-                                    'type'      => 'methodCall',
-                                    'name'      => 'user',
-                                    'class'     => 'App\Models\User',
-                                    'arguments' => [],
-                                    'children'  => [],
+                                    'type'       => 'methodCall',
+                                    'methodName' => 'user',
+                                    'className'  => 'App\Models\User',
+                                    'arguments'  => [
+                                        'type'                => 'arguments',
+                                        'autocompletingIndex' => 0,
+                                        'children'            => [],
+                                    ],
+                                    'children' => [],
                                 ],
                             ],
                         ],

--- a/tests/snippets/anonymous-function-param.php
+++ b/tests/snippets/anonymous-function-param.php
@@ -1,0 +1,4 @@
+<?php
+
+App\Models\User::where(function (\Illuminate\Database\Query\Builder $q) {
+    $q->whereIn('

--- a/tests/snippets/array-with-arrow-function-missing-second-key.php
+++ b/tests/snippets/array-with-arrow-function-missing-second-key.php
@@ -1,0 +1,5 @@
+<?php
+
+App\Models\User::with([
+    'team' => fn (\Illuminate\Database\Query\Builder $q) => $q->where('', ''),
+    '

--- a/tests/snippets/array-with-arrow-function-several-keys-and-second-param.php
+++ b/tests/snippets/array-with-arrow-function-several-keys-and-second-param.php
@@ -1,0 +1,5 @@
+<?php
+
+App\Models\User::with([
+    'team' => fn (\Illuminate\Database\Query\Builder $q) => $q->where('', ''),
+    'organization' => fn ($q) => $q->whereIn('', '

--- a/tests/snippets/array-with-arrow-function-several-keys.php
+++ b/tests/snippets/array-with-arrow-function-several-keys.php
@@ -1,0 +1,5 @@
+<?php
+
+App\Models\User::with([
+    'team' => fn (\Illuminate\Database\Query\Builder $q) => $q->where('', ''),
+    'organization' => fn ($q) => $q->whereIn('

--- a/tests/snippets/array-with-arrow-function.php
+++ b/tests/snippets/array-with-arrow-function.php
@@ -1,0 +1,3 @@
+<?php
+
+App\Models\User::with(['team' => fn (\Illuminate\Database\Query\Builder $q) => $q->where('

--- a/tests/snippets/arrow-function-param.php
+++ b/tests/snippets/arrow-function-param.php
@@ -1,0 +1,3 @@
+<?php
+
+App\Models\User::where(fn (\Illuminate\Database\Query\Builder $q) => $q->whereIn('

--- a/tests/snippets/basic-function-with-param.php
+++ b/tests/snippets/basic-function-with-param.php
@@ -1,0 +1,3 @@
+<?php
+
+render('my-view', '

--- a/tests/snippets/basic-function.php
+++ b/tests/snippets/basic-function.php
@@ -1,0 +1,3 @@
+<?php
+
+render('

--- a/tests/snippets/basic-method-with-params.php
+++ b/tests/snippets/basic-method-with-params.php
@@ -1,0 +1,5 @@
+<?php
+
+$user = new App\Models\User();
+
+$user->where('email', '

--- a/tests/snippets/basic-method.php
+++ b/tests/snippets/basic-method.php
@@ -1,0 +1,5 @@
+<?php
+
+$user = new App\Models\User();
+
+$user->where('

--- a/tests/snippets/basic-static-method-with-params.php
+++ b/tests/snippets/basic-static-method-with-params.php
@@ -1,0 +1,3 @@
+<?php
+
+App\Models\User::where('email', '

--- a/tests/snippets/basic-static-method.php
+++ b/tests/snippets/basic-static-method.php
@@ -1,0 +1,3 @@
+<?php
+
+App\Models\User::where('

--- a/tests/snippets/chained-method-with-params.php
+++ b/tests/snippets/chained-method-with-params.php
@@ -1,0 +1,5 @@
+<?php
+
+$user = new App\Models\User();
+
+$user->where('email', '')->orWhere('name', '

--- a/tests/snippets/chained-static-method-with-params.php
+++ b/tests/snippets/chained-static-method-with-params.php
@@ -1,0 +1,3 @@
+<?php
+
+App\Models\User::where('email', '')->orWhere('name', '

--- a/tests/snippets/detect/routes.php
+++ b/tests/snippets/detect/routes.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/', [HomeController::class, 'show'])->name('home.show');
+
+Route::middleware('signed')->group(function () {
+    Route::get('profile', [ProfileController::class, 'edit'])->name('profile.edit');
+});
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('dashboard', [DashboardController::class, 'show'])->name('dashboard');
+});
+
+Route::withoutMiddleware('web')
+    ->post('gitlab/webhook', [GitLabWebhookController::class, 'store'])
+    ->middleware(VerifyGitLabWebhookRequest::class)
+    ->name('gitlab.webhook.store');

--- a/tests/snippets/eloquent-make-from-set-variable.php
+++ b/tests/snippets/eloquent-make-from-set-variable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Provider;
+use Illuminate\Http\Request;
+
+class ProviderController extends Controller
+{
+    public function store(Request $request)
+    {
+        $provider = Provider::make(['

--- a/tests/snippets/nested.php
+++ b/tests/snippets/nested.php
@@ -1,0 +1,5 @@
+<?php
+
+Route::get('/', function () {
+    trans('auth.throttle');
+    App\Models\User::where('

--- a/tests/snippets/no-parse-closed-string.php
+++ b/tests/snippets/no-parse-closed-string.php
@@ -1,0 +1,3 @@
+<?php
+
+render('my-view');

--- a/tests/snippets/this-reference.php
+++ b/tests/snippets/this-reference.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Commands;
+
+use Vendor\Package\Thing;
+use Vendor\Package\Contracts\BigContract;
+use Vendor\Package\Support\Contracts\SmallContract;
+use App\Models\User;
+
+class MyCommand extends Thing implements BigContract, SmallContract
+{
+    protected User $user;
+
+    public function render(array $params)
+    {
+        $this->user->where('url', '


### PR DESCRIPTION
### What does this PR do?

`tests/Unit/ParserTest.php` and `tests/Unit/DetectTest.php` exercise
`App\Parser\Walker` and `App\Parser\DetectWalker` — both still live
production code, used from `app/Lsp/Document.php`. On a fresh clone,
19 of the 32 tests in this suite fail immediately with:

```
file_get_contents(.../tests/snippets/basic-function.php): Failed to open stream: No such file or directory
```

Root cause: `.gitignore` has `/tests/snippets`, so the fixture files these
two test files read via `fromFile()` were never committed at all (`git log
--all` shows zero history for most of them).

On top of that, the expected assertions were stale: they predate a
refactor of the `App\Contexts\*` classes that renamed `name`/`class` to
`methodName`/`className` and restructured `arguments` from a flat array
into a typed `{type: "arguments", autocompletingIndex, children}` node.
So even with the snippets restored, every non-trivial test would still
fail on content, not just the missing file.

There's no CI workflow running the test suite (only
`build-release-binaries.yml` exists), which is presumably why neither
problem was ever caught.

### Changes

- Un-ignore `/tests/snippets` in `.gitignore`.
- Add back the 17 fixture files `ParserTest.php` needs, plus
  `tests/snippets/detect/routes.php` for `DetectTest.php`. I couldn't find
  the original file contents anywhere in git history, so I reconstructed
  each one by hand — matching the scenario the test name describes (basic
  method call, chained call, closure/arrow-function param, array with
  arrow functions, class with a typed property, etc.) — and verified the
  *real* output by running `Walker`/`DetectWalker` directly against each
  candidate.
- Update both tests' expected output to the current `Context` shape,
  using that same real, driven-by-the-actual-code output rather than
  guessing at the new field names.
- Add `.github/workflows/tests.yml` (Pest on `push`/`pull_request`) so a
  regression like this can't silently sit unnoticed again.

Before: 19 failed, 1 todo, 12 passed.
After: 0 failed, 1 (pre-existing, unrelated) todo, 31 passed.

### Note

`composer.json` declares `"php": "^8.2.0"`, but the committed
`composer.lock` has since drifted to symfony/* v8.1.0 packages that
require PHP `>=8.4.1` — `composer install` fails outright on PHP 8.2/8.3
without `--ignore-platform-reqs`. I didn't touch this (different, separate
issue), but I pinned the new CI workflow to PHP 8.4 so it actually
reflects what the lockfile needs today. Flagging it here in case it's
worth its own follow-up.

### Testing

- `./vendor/bin/pest` — 31 passed, 1 todo, 0 failed (39 assertions)
- `./vendor/bin/pint --test` — passed on the changed test files