### PR TITLE
Run the pending data templates in a single process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,6 @@ It provides completion, hover, diagnostic, link, and code-action behavior.
 
 ## LSP PHP Templates
 
-- LSP data templates live in `app/Lsp/Data/Templates/` and are executed in the user's Laravel app through `ScriptRunner`.
-- `ScriptRunner` prepends `app/Lsp/Data/Templates/global.php` before executing templates through Laravel Tinker.
+- LSP data templates live in `app/Lsp/Data/Templates/` and are executed in the user's Laravel app through `ScriptRunner`, which writes them into `storage/framework/`, prepends `app/Lsp/Data/Templates/global.php` and boots the application from the process working directory (Laravel Tinker is only used when the project cannot be booted directly).
+- `ProjectIndex` runs every template that is not loaded yet in a single process through `ScriptRunner::batch()`; `configs` runs first because it snapshots application state, and a template that throws yields empty data without affecting the others.
 - Shared template helpers live in `global.php` and are exposed through `LspHelper`.

--- a/app/Lsp/Contracts/TemplateDataProvider.php
+++ b/app/Lsp/Contracts/TemplateDataProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Lsp\Contracts;
+
+interface TemplateDataProvider extends DataProvider
+{
+    /**
+     * Get the template that is run inside the user's application.
+     */
+    public function template(): string;
+
+    /**
+     * Parse the decoded template output.
+     *
+     * @param  array<mixed>  $data
+     */
+    public function parse(array $data): mixed;
+}

--- a/app/Lsp/Data/AppBindings.php
+++ b/app/Lsp/Data/AppBindings.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 use Illuminate\Support\Collection;
 
-class AppBindings implements DataProvider
+class AppBindings implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/Auth.php
+++ b/app/Lsp/Data/Auth.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class Auth implements DataProvider
+class Auth implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/BladeComponents.php
+++ b/app/Lsp/Data/BladeComponents.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class BladeComponents implements DataProvider
+class BladeComponents implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/Configs.php
+++ b/app/Lsp/Data/Configs.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class Configs implements DataProvider
+class Configs implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/CustomBladeDirectives.php
+++ b/app/Lsp/Data/CustomBladeDirectives.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class CustomBladeDirectives implements DataProvider
+class CustomBladeDirectives implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/DebugInfo.php
+++ b/app/Lsp/Data/DebugInfo.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class DebugInfo implements DataProvider
+class DebugInfo implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/InertiaViews.php
+++ b/app/Lsp/Data/InertiaViews.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 use Illuminate\Support\Collection;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class InertiaViews implements DataProvider
+class InertiaViews implements TemplateDataProvider
 {
     /**
      * Create a new inertia views provider instance.

--- a/app/Lsp/Data/Middleware.php
+++ b/app/Lsp/Data/Middleware.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 use Illuminate\Support\Collection;
 
-class Middleware implements DataProvider
+class Middleware implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/Models.php
+++ b/app/Lsp/Data/Models.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class Models implements DataProvider
+class Models implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/Paths.php
+++ b/app/Lsp/Data/Paths.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 use Illuminate\Support\Collection;
 
-class Paths implements DataProvider
+class Paths implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/Routes.php
+++ b/app/Lsp/Data/Routes.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
+use Illuminate\Support\Collection;
 
-class Routes implements DataProvider
+class Routes implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.
@@ -18,11 +19,31 @@ class Routes implements DataProvider
     }
 
     /**
+     * Get the routes template to run.
+     */
+    public function template(): string
+    {
+        return file_get_contents(__DIR__ . '/Templates/routes.php') ?: '';
+    }
+
+    /**
+     * Parse the routes template output.
+     *
+     * @param  array<int, array<string, mixed>>  $data
+     */
+    public function parse(array $data): Collection
+    {
+        return collect($data);
+    }
+
+    /**
      * Get data.
      */
-    public function get(): mixed
+    public function get(): Collection
     {
-        return collect($this->project->scripts->json(file_get_contents(__DIR__ . '/Templates/routes.php')));
+        $data = $this->project->scripts->json($this->template());
+
+        return $this->parse(is_array($data) ? $data : []);
     }
 
     /**

--- a/app/Lsp/Data/Templates/blade-components.php
+++ b/app/Lsp/Data/Templates/blade-components.php
@@ -368,6 +368,8 @@ $components = new class
 
         $result = '';
 
+        $compiler = clone $compiler;
+
         $compiler->directive('props', function ($expression) use (&$result) {
             return $result = $expression;
         });

--- a/app/Lsp/Data/Tests.php
+++ b/app/Lsp/Data/Tests.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class Tests implements DataProvider
+class Tests implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/Translations.php
+++ b/app/Lsp/Data/Translations.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 
-class Translations implements DataProvider
+class Translations implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Data/Views.php
+++ b/app/Lsp/Data/Views.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Lsp\Data;
 
-use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Project;
 use Illuminate\Support\Collection;
 
-class Views implements DataProvider
+class Views implements TemplateDataProvider
 {
     /**
      * Instantiate a new class instance.

--- a/app/Lsp/Methods/Initialize.php
+++ b/app/Lsp/Methods/Initialize.php
@@ -45,11 +45,13 @@ final class Initialize implements Method
 
         $this->container->singleton(Project::class);
 
+        $scripts = new ScriptRunner($uri->path(), $this->phpCommand($request, $uri));
+
         $project = new Project(
             $uri,
             $request->array('initializationOptions'),
-            new ProjectIndex($this->container),
-            new ScriptRunner($uri->path(), $this->phpCommand($request, $uri)),
+            new ProjectIndex($this->container, $scripts),
+            $scripts,
         );
 
         $this->container->instance(Project::class, $project);

--- a/app/Lsp/ProjectIndex.php
+++ b/app/Lsp/ProjectIndex.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Lsp;
 
 use App\Lsp\Contracts\DataProvider;
+use App\Lsp\Contracts\TemplateDataProvider;
 use App\Lsp\Data\AppBindings;
 use App\Lsp\Data\Assets;
 use App\Lsp\Data\Auth;
@@ -57,6 +58,16 @@ class ProjectIndex
     ];
 
     /**
+     * Template providers whose data is a snapshot of application state.
+     *
+     * Their templates run before the others share a process with them, so
+     * the snapshot is not changed by whatever the other templates touch.
+     *
+     * @var array<int, string>
+     */
+    protected array $snapshots = ['configs'];
+
+    /**
      * Loaded project data.
      *
      * @var array<string, mixed>
@@ -66,10 +77,10 @@ class ProjectIndex
     /**
      * Instantiate a new class instance.
      */
-    public function __construct(protected Container $container)
-    {
-        //
-    }
+    public function __construct(
+        protected Container $container,
+        protected ScriptRunner $scripts,
+    ) {}
 
     /**
      * Get the app bindings provider.
@@ -220,7 +231,11 @@ class ProjectIndex
      */
     public function get(string $name): mixed
     {
-        return $this->loaded[$name] ??= $this->load($name);
+        if (!isset($this->loaded[$name])) {
+            $this->load($name);
+        }
+
+        return $this->loaded[$name];
     }
 
     /**
@@ -240,15 +255,69 @@ class ProjectIndex
     }
 
     /**
-     * Get the data.
+     * Load the data.
      */
-    protected function load(string $name): mixed
+    protected function load(string $name): void
     {
         if (! isset($this->providers[$name])) {
             throw new DataProviderNotFoundException($name);
         }
 
-        return $this->container->make($this->providers[$name])->get();
+        $provider = $this->container->make($this->providers[$name]);
+
+        if ($provider instanceof TemplateDataProvider) {
+            $this->loadTemplates();
+
+            return;
+        }
+
+        $this->loaded[$name] = $provider->get();
+    }
+
+    /**
+     * Load every template provider that is not loaded yet.
+     *
+     * Booting the application dominates the cost of running a template, so the
+     * pending templates run in a single process and share one boot.
+     */
+    protected function loadTemplates(): void
+    {
+        $providers = array_filter(
+            $this->templateProviders(),
+            fn (string $name): bool => !isset($this->loaded[$name]),
+            ARRAY_FILTER_USE_KEY,
+        );
+
+        $data = $this->scripts->batch(array_map(
+            fn (TemplateDataProvider $provider): string => $provider->template(),
+            $providers,
+        ));
+
+        foreach ($providers as $name => $provider) {
+            $this->loaded[$name] = $provider->parse(is_array($data[$name] ?? null) ? $data[$name] : []);
+        }
+    }
+
+    /**
+     * Get the template providers in the order their templates run.
+     *
+     * @return array<string, TemplateDataProvider>
+     */
+    protected function templateProviders(): array
+    {
+        $providers = [];
+
+        foreach ($this->providers as $name => $class) {
+            $provider = $this->container->make($class);
+
+            if ($provider instanceof TemplateDataProvider) {
+                $providers[$name] = $provider;
+            }
+        }
+
+        $snapshots = array_flip($this->snapshots);
+
+        return array_intersect_key($providers, $snapshots) + array_diff_key($providers, $snapshots);
     }
 
     /**

--- a/app/Lsp/ScriptRunner.php
+++ b/app/Lsp/ScriptRunner.php
@@ -20,6 +20,14 @@ class ScriptRunner
     protected ?bool $bootable = null;
 
     /**
+     * Whether scripts may share a process.
+     *
+     * Turned off once a shared process fails, so a project that cannot run
+     * its scripts together does not pay for the attempt on every load.
+     */
+    protected bool $batchable = true;
+
+    /**
      * Create a new PHP runner instance.
      *
      * @param  array<int, string>  $command
@@ -40,7 +48,7 @@ class ScriptRunner
     }
 
     /**
-     * Run PHP code in the user's Laravel application via artisan tinker.
+     * Run PHP code in the user's Laravel application.
      */
     public function run(string $code): ?string
     {
@@ -55,6 +63,158 @@ class ScriptRunner
             return null;
         }
 
+        try {
+            return $this->execute($script);
+        } finally {
+            @unlink($this->path . '/' . $script);
+        }
+    }
+
+    /**
+     * Run several PHP scripts in the user's Laravel application and decode each output as JSON.
+     *
+     * Booting the application dominates the cost of a script, so the scripts share a
+     * single process. Each one runs in its own scope with its output captured on its
+     * own, and a script that throws yields null without affecting the others. When the
+     * shared process fails, every script is run on its own instead, now and for the
+     * rest of the session.
+     *
+     * @param  array<string, string>  $codes
+     * @return array<string, mixed>
+     */
+    public function batch(array $codes): array
+    {
+        if ($codes === []) {
+            return [];
+        }
+
+        if (count($codes) === 1) {
+            return array_map($this->json(...), $codes);
+        }
+
+        $outputs = $this->batchable ? $this->runBatch($codes) : null;
+
+        if ($outputs === null) {
+            $this->batchable = false;
+
+            $outputs = array_map($this->run(...), $codes);
+        }
+
+        return array_map($this->decode(...), $outputs);
+    }
+
+    /**
+     * Run the given scripts in a single process and capture each output.
+     *
+     * @param  array<string, string>  $codes
+     * @return array<string, string|null>|null
+     */
+    protected function runBatch(array $codes): ?array
+    {
+        $id = bin2hex(random_bytes(8));
+        $scripts = [];
+        $written = [];
+
+        foreach (array_keys($codes) as $index => $key) {
+            $scripts[$key] = 'lsp-' . $id . '-' . $index . '.php';
+        }
+
+        try {
+            foreach ($codes as $key => $code) {
+                $file = $this->store($scripts[$key], '<?php' . PHP_EOL . $this->normalize($code));
+
+                if ($file === null) {
+                    return null;
+                }
+
+                $written[] = $file;
+            }
+
+            $script = $this->write($this->batchCode($scripts));
+
+            if ($script === null) {
+                return null;
+            }
+
+            $written[] = $script;
+
+            return $this->outputs($this->execute($script), $codes);
+        } finally {
+            foreach ($written as $file) {
+                @unlink($this->path . '/' . $file);
+            }
+        }
+    }
+
+    /**
+     * Get the code that runs the given scripts one after another and reports every output.
+     *
+     * Each script is included inside its own closure so its variables stay local, the
+     * error level is restored before each one, and the script's own output is buffered.
+     *
+     * @param  array<string, string>  $scripts
+     */
+    protected function batchCode(array $scripts): string
+    {
+        return implode(PHP_EOL, [
+            '$__level = error_reporting();',
+            '$__outputs = [];',
+            '$__errors = [];',
+            'foreach (' . var_export($scripts, true) . ' as $__key => $__script) {',
+            '    error_reporting($__level);',
+            '    ob_start();',
+            '    try {',
+            "        (static function () use (\$__script) { include __DIR__ . '/' . \$__script; })();",
+            '        $__outputs[$__key] = ob_get_clean();',
+            '    } catch (Throwable $__e) {',
+            '        ob_end_clean();',
+            '        $__outputs[$__key] = null;',
+            "        \$__errors[\$__key] = get_class(\$__e) . ': ' . \$__e->getMessage() . ' in ' . \$__e->getFile() . ':' . \$__e->getLine();",
+            '    }',
+            '}',
+            "echo json_encode(['outputs' => \$__outputs, 'errors' => \$__errors]);",
+        ]);
+    }
+
+    /**
+     * Extract the output of every script from the output of the shared process.
+     *
+     * @param  array<string, string>  $codes
+     * @return array<string, string|null>|null
+     */
+    protected function outputs(?string $output, array $codes): ?array
+    {
+        $decoded = $output === null ? null : json_decode($output, true);
+
+        if (!is_array($decoded) || !is_array($decoded['outputs'] ?? null)) {
+            return null;
+        }
+
+        foreach ($decoded['errors'] ?? [] as $key => $error) {
+            info('PHP runner error.', [
+                'script' => $key,
+                'error'  => $error,
+            ]);
+        }
+
+        $outputs = [];
+
+        foreach (array_keys($codes) as $key) {
+            if (!array_key_exists($key, $decoded['outputs'])) {
+                return null;
+            }
+
+            $outputs[$key] = is_string($decoded['outputs'][$key]) ? $decoded['outputs'][$key] : null;
+        }
+
+        return $outputs;
+    }
+
+    /**
+     * Execute the given script and get its output.
+     */
+    protected function execute(string $script): ?string
+    {
         try {
             $process = new Process($this->arguments($script), $this->path, timeout: null);
 
@@ -76,8 +236,6 @@ class ScriptRunner
             report($e);
 
             return null;
-        } finally {
-            @unlink($this->path . '/' . $script);
         }
     }
 
@@ -132,7 +290,15 @@ class ScriptRunner
      */
     protected function write(string $code): ?string
     {
-        $script = 'storage/framework/lsp-' . bin2hex(random_bytes(8)) . '.php';
+        return $this->store('lsp-' . bin2hex(random_bytes(8)) . '.php', $this->code($code));
+    }
+
+    /**
+     * Store a file inside the project's framework storage.
+     */
+    protected function store(string $name, string $contents): ?string
+    {
+        $script = 'storage/framework/' . $name;
         $path = $this->path . '/' . $script;
         $directory = dirname($path);
 
@@ -140,7 +306,7 @@ class ScriptRunner
             return null;
         }
 
-        return @file_put_contents($path, $this->code($code)) === false ? null : $script;
+        return @file_put_contents($path, $contents) === false ? null : $script;
     }
 
     /**
@@ -172,8 +338,14 @@ class ScriptRunner
      */
     public function json(string $code): mixed
     {
-        $output = $this->run($code);
+        return $this->decode($this->run($code));
+    }
 
+    /**
+     * Decode the output of a script as JSON.
+     */
+    protected function decode(?string $output): mixed
+    {
         if ($output === null) {
             return null;
         }

--- a/tests/Unit/MemoryLimitTest.php
+++ b/tests/Unit/MemoryLimitTest.php
@@ -8,11 +8,13 @@ use Illuminate\Container\Container;
 
 function memoryLimitProject(array $init = []): Project
 {
+    $scripts = new ScriptRunner('/tmp/laravel-lsp-project', ['php']);
+
     return new Project(
         FileUri::of('file:///tmp/laravel-lsp-project'),
         $init,
-        new ProjectIndex(new Container),
-        new ScriptRunner('/tmp/laravel-lsp-project', ['php']),
+        new ProjectIndex(new Container, $scripts),
+        $scripts,
     );
 }
 

--- a/tests/Unit/ProjectIndexTest.php
+++ b/tests/Unit/ProjectIndexTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use App\Lsp\Project;
+use App\Lsp\ProjectIndex;
+use App\Lsp\ScriptRunner;
+use App\Lsp\Support\FileUri;
+use Illuminate\Container\Container;
+use Illuminate\Support\Collection;
+
+function projectIndexScripts(array $data = []): ScriptRunner
+{
+    return new class('/tmp/laravel-lsp-project', ['php'], $data) extends ScriptRunner
+    {
+        /**
+         * @var array<int, array<int, string>>
+         */
+        public array $batches = [];
+
+        public function __construct(string $path, array $command, protected array $data)
+        {
+            parent::__construct($path, $command);
+        }
+
+        public function batch(array $codes): array
+        {
+            $this->batches[] = array_keys($codes);
+
+            $results = [];
+
+            foreach (array_keys($codes) as $key) {
+                $results[$key] = $this->data[$key] ?? null;
+            }
+
+            return $results;
+        }
+
+        public function run(string $code): ?string
+        {
+            throw new RuntimeException('No script should run on its own.');
+        }
+    };
+}
+
+function projectIndex(ScriptRunner $scripts): ProjectIndex
+{
+    $container = new Container;
+    $index = new ProjectIndex($container, $scripts);
+
+    $container->instance(Project::class, new Project(
+        FileUri::of('file:///tmp/laravel-lsp-project'),
+        [],
+        $index,
+        $scripts,
+    ));
+
+    return $index;
+}
+
+test('loading a template provider runs every unloaded template in one batch with snapshots first', function () {
+    $scripts = projectIndexScripts();
+    $index = projectIndex($scripts);
+
+    $index->routes();
+
+    expect($scripts->batches)->toBe([[
+        'configs',
+        'appBindings',
+        'auth',
+        'bladeComponents',
+        'customBladeDirectives',
+        'debugInfo',
+        'inertiaViews',
+        'middleware',
+        'models',
+        'paths',
+        'routes',
+        'tests',
+        'translations',
+        'views',
+    ]]);
+
+    $index->views();
+    $index->configs();
+    $index->tests();
+
+    expect($scripts->batches)->toHaveCount(1);
+});
+
+test('template output is parsed by its provider', function () {
+    $index = projectIndex(projectIndexScripts([
+        'routes' => [['name' => 'home']],
+        'paths'  => ['base' => '/app'],
+        'tests'  => ['Unit' => []],
+    ]));
+
+    expect($index->routes())->toBeInstanceOf(Collection::class)
+        ->and($index->routes()->all())->toBe([['name' => 'home']])
+        ->and($index->paths()->all())->toBe(['base' => '/app'])
+        ->and($index->tests())->toBe(['Unit' => []]);
+});
+
+test('a template without valid output loads as empty data', function () {
+    $index = projectIndex(projectIndexScripts([
+        'routes' => [['name' => 'home']],
+        'views'  => 'not an array',
+        'tests'  => null,
+    ]));
+
+    expect($index->views()->all())->toBe([])
+        ->and($index->tests())->toBe([])
+        ->and($index->routes()->all())->toBe([['name' => 'home']]);
+});
+
+test('providers without a template load on their own', function () {
+    $scripts = projectIndexScripts();
+    $index = projectIndex($scripts);
+
+    expect($index->env()->all())->toBe([])
+        ->and($scripts->batches)->toBe([]);
+});
+
+test('invalidating reloads only the affected templates', function () {
+    $scripts = projectIndexScripts();
+    $index = projectIndex($scripts);
+
+    $index->routes();
+    $index->invalidate(['routes/web.php']);
+    $index->views();
+
+    expect($scripts->batches)->toHaveCount(1);
+
+    $index->routes();
+
+    expect($scripts->batches)->toHaveCount(2)
+        ->and($scripts->batches[1])->toBe(['routes']);
+});
+
+test('invalidated templates reload together with snapshots first', function () {
+    $scripts = projectIndexScripts();
+    $index = projectIndex($scripts);
+
+    $index->routes();
+    $index->invalidate(['config/app.php']);
+    $index->paths();
+
+    expect($scripts->batches)->toHaveCount(2)
+        ->and($scripts->batches[1])->toBe(['configs', 'inertiaViews', 'paths']);
+});

--- a/tests/Unit/ScriptRunnerTest.php
+++ b/tests/Unit/ScriptRunnerTest.php
@@ -131,3 +131,114 @@ test('the bootstrap is empty when the project cannot be booted without artisan',
         scriptRunnerCleanup($root);
     }
 });
+
+test('a batch runs every script in a single process', function () {
+    $root = scriptRunnerProject('batch');
+
+    try {
+        expect(scriptRunnerFor($root)->batch([
+            'first'  => 'define("SCRIPT_RUNNER_FIRST", true); echo json_encode(SCRIPT_RUNNER_BOOTED);',
+            'second' => '<?php echo json_encode(defined("SCRIPT_RUNNER_FIRST"));',
+            'third'  => 'use Random\Randomizer; echo json_encode((new Randomizer)->getInt(3, 3));',
+        ]))->toBe(['first' => true, 'second' => true, 'third' => 3]);
+    } finally {
+        scriptRunnerCleanup($root);
+    }
+});
+
+test('a batch keeps the variables of each script to itself', function () {
+    $root = scriptRunnerProject('batch-scope');
+
+    try {
+        expect(scriptRunnerFor($root)->batch([
+            'first'  => '$shared = 1; echo json_encode($shared);',
+            'second' => 'echo json_encode(isset($shared));',
+        ]))->toBe(['first' => 1, 'second' => false]);
+    } finally {
+        scriptRunnerCleanup($root);
+    }
+});
+
+test('a batch reports a script that throws without affecting the others', function () {
+    $root = scriptRunnerProject('batch-throws');
+
+    try {
+        expect(scriptRunnerFor($root)->batch([
+            'first'  => 'define("SCRIPT_RUNNER_FIRST", true); echo json_encode(1);',
+            'second' => 'echo "partial"; throw new RuntimeException("boom");',
+            'third'  => 'echo json_encode(defined("SCRIPT_RUNNER_FIRST"));',
+        ]))->toBe(['first' => 1, 'second' => null, 'third' => true]);
+    } finally {
+        scriptRunnerCleanup($root);
+    }
+});
+
+test('a batch runs each script on its own when the shared process fails', function () {
+    $root = scriptRunnerProject('batch-fails');
+
+    try {
+        $runner = scriptRunnerFor($root);
+
+        expect($runner->batch([
+            'first'  => 'define("SCRIPT_RUNNER_FIRST", true); echo json_encode(1);',
+            'second' => 'exit(1);',
+            'third'  => 'echo json_encode(defined("SCRIPT_RUNNER_FIRST"));',
+        ]))->toBe(['first' => 1, 'second' => null, 'third' => false]);
+
+        expect($runner->batch([
+            'first'  => 'define("SCRIPT_RUNNER_FIRST", true); echo json_encode(1);',
+            'second' => 'echo json_encode(defined("SCRIPT_RUNNER_FIRST"));',
+        ]))->toBe(['first' => 1, 'second' => false]);
+    } finally {
+        scriptRunnerCleanup($root);
+    }
+});
+
+test('a batch with a single script runs it directly', function () {
+    $root = scriptRunnerProject('batch-single');
+
+    try {
+        expect(scriptRunnerFor($root)->batch(['only' => 'echo json_encode(SCRIPT_RUNNER_BOOTED);']))
+            ->toBe(['only' => true])
+            ->and(scriptRunnerFor($root)->batch([]))
+            ->toBe([]);
+    } finally {
+        scriptRunnerCleanup($root);
+    }
+});
+
+test('a batch resolves the scripts inside the PHP environment', function () {
+    $host = scriptRunnerProject('batch-host');
+    $runtime = scriptRunnerProject('batch-runtime');
+
+    try {
+        mkdir($runtime . '/storage/framework', 0777, true);
+
+        $runner = new class($host, ['php'], $runtime) extends ScriptRunner
+        {
+            public function __construct(string $path, array $command, protected string $runtime)
+            {
+                parent::__construct($path, $command);
+            }
+
+            protected function execute(string $script): ?string
+            {
+                foreach (glob($this->path . '/storage/framework/lsp-*.php') ?: [] as $file) {
+                    copy($file, $this->runtime . '/storage/framework/' . basename($file));
+                }
+
+                $process = new Process([PHP_BINARY, $script], $this->runtime);
+                $process->mustRun();
+
+                return $process->getOutput();
+            }
+        };
+
+        expect($runner->batch([
+            'first'  => 'echo json_encode(SCRIPT_RUNNER_PROJECT);',
+            'second' => 'echo json_encode(SCRIPT_RUNNER_PROJECT);',
+        ]))->toBe(['first' => realpath($runtime), 'second' => realpath($runtime)]);
+    } finally {
+        scriptRunnerCleanup($host, $runtime);
+    }
+});


### PR DESCRIPTION
after #84 we still boot laravel once per provider. opening a php file touches most of the 14 template providers, so thats 14 boots before the first diagnostics show up.

this makes `ProjectIndex` load every template provider that isnt loaded yet in one `ScriptRunner::batch()` call, so the app boots once. measured through the real classes on four apps, medians of 3:

| app | laravel | 14 processes | 1 process |
|---|---|---|---|
| app 1 | 10 | 3.49 s | 0.37 s |
| app 2 | 11 | 3.55 s | 0.43 s |
| app 3 | 12 | 4.11 s | 0.66 s |
| app 4 | 13 | 6.92 s | 2.99 s |

provider output is byte identical to running each `get()` on its own, 14/14 on all four. same result through the tinker path.

how it runs. each template is written next to the batch script and included inside its own static closure, so variables stay local like they do in a separate process. output is buffered per template and the error level is restored before each one. a template that throws gives null for that one and gets logged with file and line, the rest are unaffected. if the shared process itself dies every template runs on its own, which is exactly todays path, and it stays that way for the session. an invalidation that only touches one provider has nothing to batch so it goes through the existing single script path unchanged.

`configs` runs first. a deprecation raised before it makes `HandleExceptions` add `logging.channels.deprecations.*` to the config, reproduced on 12. none of the shipped templates trigger that on these four apps (all 182 ordered pairs per app, 0 sensitive) but user code booting a model could.

`blade-components` registers a `props` directive on the shared compiler, which leaks into `blade-directives` once they share a process, so it clones the compiler first.

no host paths in the generated files, same runtime test as #84. invalidation is untouched, checked on a real app by adding a route, invalidating `routes/web.php` and seeing only `routes` rerun. the 13 providers just switch to `TemplateDataProvider`, `Routes` gets `template()` and `parse()` like the others, `get()` is untouched everywhere.

one trade. a session that only ever needs one provider pays for the full batch on first load instead of one template. diagnostics on a php file need most of them so i dont think it matters in practice, flagging anyway.

whats left is template time not boot. `translations` is 2.2 s of the 3.0 s on app 4 and `models` is 250 ms of the 660 ms on app 3. separate PRs.
